### PR TITLE
[58] Portalmenü Fix and Styling

### DIFF
--- a/components/blocks/fau-portalmenu/EditorPreview.jsx
+++ b/components/blocks/fau-portalmenu/EditorPreview.jsx
@@ -14,28 +14,6 @@ const FALLBACK_IMAGE =
  * Shows actual menu items from the selected menu
  */
 const EditorPreview = ( { attributes } ) => {
-	// Configuration classes that match the backend config
-	const CSS_CLASSES = {
-		container: 'contentmenu',
-		menu_list: 'subpages-menu',
-		portal_item: 'portal-item',
-		portal_thumbnail: 'portal-thumbnail',
-		portal_content: 'portal-content',
-		portal_title: 'portal-title',
-		portal_main_link: 'portal-main-link',
-		portal_button_arrow: 'portal-button-arrow',
-		portal_submenu: 'portal-submenu',
-		portal_subitem: 'portal-subitem',
-		portal_sublink: 'portal-sublink',
-		screen_reader_text: 'screen-reader-text',
-		image_link: 'image-link',
-		list_view: 'listview',
-		no_thumb: 'no-thumb',
-		hover_zoom: 'hover-zoom',
-		hover_blur: 'hover-blur',
-		dark_style: 'is-style-dark',
-	};
-
 	// Fetch actual menu items
 	const menuItems = useSelect(
 		( select ) => {
@@ -243,66 +221,45 @@ const EditorPreview = ( { attributes } ) => {
 							<span></span>
 						</a>
 
-						{ showSubs && (
-							<div
-								className={ CSS_CLASSES.portal_submenu }
-								role="list"
-							>
-								{ hasChildren &&
-									item.children.map( ( child ) => {
-										const childTitle =
-											child.title?.rendered ||
-											child.title ||
-											__(
-												'Submenu Item',
-												'fau-elemental'
-											);
-										return (
-											<div
-												key={ child.id }
-												className={
-													CSS_CLASSES.portal_subitem
+						{ showSubs && hasChildren && (
+							<ul>
+								{ item.children.map( ( child ) => {
+									const childTitle =
+										child.title?.rendered ||
+										child.title ||
+										__( 'Submenu Item', 'fau-elemental' );
+									return (
+										<li key={ child.id }>
+											{ /* eslint-disable-next-line jsx-a11y/anchor-is-valid */ }
+											<a
+												role="link"
+												aria-label={ sprintf(
+													// translators: %s: Submenu item title
+													__(
+														'Go to %s',
+														'fau-elemental'
+													),
+													childTitle
+												) }
+												tabIndex="0"
+												onClick={ ( e ) =>
+													e.preventDefault()
 												}
-												role="listitem"
+												onKeyDown={ ( e ) => {
+													if (
+														e.key === 'Enter' ||
+														e.key === ' '
+													) {
+														e.preventDefault();
+													}
+												} }
 											>
-												<div
-													onClick={ ( e ) =>
-														e.preventDefault()
-													}
-													className={
-														CSS_CLASSES.portal_sublink
-													}
-													role="link"
-													aria-label={ sprintf(
-														// translators: %s: Submenu item title
-														__(
-															'Go to %s',
-															'fau-elemental'
-														),
-														childTitle
-													) }
-													tabIndex="0"
-													onKeyDown={ ( e ) => {
-														if (
-															e.key === 'Enter' ||
-															e.key === ' '
-														) {
-															e.preventDefault();
-														}
-													} }
-												>
-													<span className="portal-link-text">
-														{ childTitle }
-													</span>
-													<span
-														className="portal-link-button"
-														aria-hidden="true"
-													></span>
-												</div>
-											</div>
-										);
-									} ) }
-							</div>
+												{ childTitle }
+											</a>
+										</li>
+									);
+								} ) }
+							</ul>
 						) }
 					</div>
 				</div>
@@ -310,9 +267,14 @@ const EditorPreview = ( { attributes } ) => {
 		);
 	};
 
+	let menuClasses = 'fau-portal-menu';
+	if ( attributes.isDark ) {
+		menuClasses += ' is-style-dark';
+	}
+
 	return (
 		<div
-			className="fau-portal-menu"
+			className={ menuClasses }
 			aria-label={ __( 'Portal Menu', 'fau-elemental' ) }
 		>
 			{ menuItems && menuItems.length > 0 ? (

--- a/components/blocks/fau-portalmenu/EditorPreview.jsx
+++ b/components/blocks/fau-portalmenu/EditorPreview.jsx
@@ -267,46 +267,47 @@ const EditorPreview = ( { attributes } ) => {
 		);
 	};
 
-	let menuClasses = 'fau-portal-menu';
-	if ( attributes.isDark ) {
-		menuClasses += ' is-style-dark';
-	}
-
 	return (
 		<div
-			className={ menuClasses }
-			aria-label={ __( 'Portal Menu', 'fau-elemental' ) }
+			className={ `wp-block-group${
+				attributes.isDark ? ' is-style-dark' : ''
+			}` }
 		>
-			{ menuItems && menuItems.length > 0 ? (
-				menuItems.map( ( item ) => renderMenuItem( item ) )
-			) : menuItems && menuItems.length === 0 ? (
-				<div
-					className="fau-portal-empty-state"
-					role="status"
-					aria-live="polite"
-				>
-					{ __(
-						'This menu has no items. Please add items to the menu in Appearance → Menus.',
-						'fau-elemental'
-					) }
-				</div>
-			) : attributes.menuId && ! menuItems ? (
-				<div
-					className="fau-portal-loading-state"
-					role="status"
-					aria-live="polite"
-				>
-					{ __( 'Loading menu items…', 'fau-elemental' ) }
-				</div>
-			) : (
-				<div
-					className="fau-portal-no-menu-state"
-					role="status"
-					aria-live="polite"
-				>
-					{ __( 'No menu selected', 'fau-elemental' ) }
-				</div>
-			) }
+			<div
+				className="fau-portal-menu"
+				aria-label={ __( 'Portal Menu', 'fau-elemental' ) }
+			>
+				{ menuItems && menuItems.length > 0 ? (
+					menuItems.map( ( item ) => renderMenuItem( item ) )
+				) : menuItems && menuItems.length === 0 ? (
+					<div
+						className="fau-portal-empty-state"
+						role="status"
+						aria-live="polite"
+					>
+						{ __(
+							'This menu has no items. Please add items to the menu in Appearance → Menus.',
+							'fau-elemental'
+						) }
+					</div>
+				) : attributes.menuId && ! menuItems ? (
+					<div
+						className="fau-portal-loading-state"
+						role="status"
+						aria-live="polite"
+					>
+						{ __( 'Loading menu items…', 'fau-elemental' ) }
+					</div>
+				) : (
+					<div
+						className="fau-portal-no-menu-state"
+						role="status"
+						aria-live="polite"
+					>
+						{ __( 'No menu selected', 'fau-elemental' ) }
+					</div>
+				) }
+			</div>
 		</div>
 	);
 };

--- a/components/blocks/fau-portalmenu/block.json
+++ b/components/blocks/fau-portalmenu/block.json
@@ -59,6 +59,5 @@
 	"textdomain": "fau-elemental",
 	"editorScript": "file:./index.js",
 	"editorStyle": "file:./editor.css",
-	"style": "file:./style-theme.css",
 	"render": "file:./render.php"
 }

--- a/components/blocks/fau-portalmenu/render.php
+++ b/components/blocks/fau-portalmenu/render.php
@@ -32,14 +32,6 @@ $show_subs = isset($attributes['showSubs']) ? !empty($attributes['showSubs']) : 
 $no_thumbs = isset($attributes['noThumbs']) ? !empty($attributes['noThumbs']) : FAU_Elemental_Portal_Menu_Config::get_default('hide_thumbs');
 $is_dark =   isset($attributes['isDark'])   ? !empty($attributes['isDark'])   : FAU_Elemental_Portal_Menu_Config::get_default('is_dark');
 
-
-$portal_classes = array('fau-portal-menu');
-
-// Add classes based on options
-if ($is_dark) {
-    $portal_classes[] = 'is-style-dark';
-}
-
 // Create Walker instance with settings
 $walker = new Walker_Content_Menu([
     'showsubs' => $show_subs,
@@ -57,7 +49,8 @@ if (is_numeric($menu)) {
     }
 }
 
-echo '<div class="' . implode(' ', $portal_classes) . '" role="navigation" aria-label="' . __('Portal Menu', 'fau-elemental') . '">' . "\n";
+echo '<div class="wp-block-group' . ($is_dark ? ' is-style-dark' : '') . '">' . "\n";
+echo '<div class="fau-portal-menu" role="navigation" aria-label="' . __('Portal Menu', 'fau-elemental') . '">' . "\n";
 
 // Render the menu
 wp_nav_menu([
@@ -71,4 +64,4 @@ wp_nav_menu([
     'walker' => $walker
 ]);
 
-echo '</div>';
+echo '</div></div>';

--- a/components/blocks/fau-portalmenu/style.scss
+++ b/components/blocks/fau-portalmenu/style.scss
@@ -8,8 +8,8 @@
 
 .fau-portal-menu {
 	display: grid;
-	grid-template-columns: repeat(3, 1fr);
-	gap: var(--Spacing-8x);
+	grid-template-columns: repeat(2, 1fr);
+	gap: 0 var(--Spacing-8x);
 	max-width: var(--wide-max-width);
 	margin: 0 auto;
 	padding: var(--Spacing-10x);
@@ -18,6 +18,8 @@
 		display: flex;
 		align-items: center;
 		flex-direction: column;
+		padding-bottom: var(--Spacing-6x);
+		border-bottom: 0.0625rem solid var(--FAU-Col-FAU-Schwarz-37_5);
 
 		.fau-portal-thumbnail {
 			width: 100%;
@@ -31,16 +33,15 @@
 		}
 
 		.fau-portal-wrapper {
-			position: relative;
-			bottom: var(--Spacing-10x);
-			width: 90%;
+			width: 100%;
 
 			.fau-portal-content {
-				padding: var(--Spacing-4x) 0 var(--Spacing-4x) var(--Spacing-6x);
+				padding: var(--Spacing-8x) var(--Spacing-8x) 0 0;
 				background-color: var(--FAU-Col-FAU-Weiss-100);
 
 				a {
 					text-decoration: none;
+					font-size: 1rem;
 					letter-spacing: var(--letter-spacing-big);
 				}
 
@@ -51,11 +52,13 @@
 
 					h3 {
 						margin: 0;
+						font-size: 1.25rem;
 					}
 
 					span {
 						position: relative;
 						display: block;
+						transform: translateX(var(--Spacing-8x));
 						padding: 0;
 						height: 2.5rem;
 						width: 2.5rem;
@@ -124,21 +127,69 @@
 				}
 			}
 		}
+
+		.fau-portal-thumbnail + .fau-portal-wrapper {
+			position: relative;
+			bottom: var(--Spacing-10x);
+			width: 90%;
+		}
+	}
+
+	// Style when Thumbnail is active
+	&:has(.fau-portal-thumbnail) {
+		grid-template-columns: repeat(3, 1fr);
+
+		.fau-portal-item {
+			padding-bottom: 0;
+			border-bottom: none;
+
+			.fau-portal-wrapper .fau-portal-content {
+				padding: var(--Spacing-4x) var(--Spacing-8x) 0 var(--Spacing-4x);
+			}
+		}
+	}
+}
+
+// ToDo: Add faculty colors
+
+//Dark Mode
+.fau-portal-menu.is-style-dark {
+	background-color: var(--FAU-Col-FAU-Blau-100);
+
+	.fau-portal-item .fau-portal-wrapper .fau-portal-content {
+		background-color: var(--FAU-Col-FAU-Blau-100);
+
+		ul li a::before {
+			background-image: var(--icon-arrow-weiss);
+		}
+
+		> a span {
+			background-color: var(--FAU-Col-FAU-Dunkelblau-12_5);
+
+			&::before {
+				background-image: var(--icon-arrow-fau-blau);
+			}
+		}
 	}
 }
 
 // Responsive
 @media screen and (max-width: 999px) {
 
-	.fau-portal-menu {
+	.fau-portal-menu:has(.fau-portal-thumbnail) {
 		grid-template-columns: repeat(2, 1fr);
 	}
 }
 
-@include respond-to("small") {
+@media screen and (max-width: 599px) {
 
-	.fau-portal-menu {
+	.fau-portal-menu,
+	.fau-portal-menu:has(.fau-portal-thumbnail) {
 		grid-template-columns: 1fr;
+	}
+
+	.fau-portal-menu .fau-portal-item .fau-portal-wrapper .fau-portal-content {
+		padding: var(--Spacing-6x) var(--Spacing-8x) 0 0;
 	}
 }
 

--- a/components/blocks/fau-portalmenu/style.scss
+++ b/components/blocks/fau-portalmenu/style.scss
@@ -10,8 +10,7 @@
 	display: grid;
 	grid-template-columns: repeat(2, 1fr);
 	gap: 0 var(--Spacing-8x);
-	max-width: var(--wide-max-width);
-	margin: 0 auto;
+	max-width: var(--base-max-width);
 	padding: var(--Spacing-10x);
 
 	.fau-portal-item {
@@ -138,6 +137,7 @@
 	// Style when Thumbnail is active
 	&:has(.fau-portal-thumbnail) {
 		grid-template-columns: repeat(3, 1fr);
+		max-width: var(--wide-max-width);
 
 		.fau-portal-item {
 			padding-bottom: 0;
@@ -153,21 +153,24 @@
 // ToDo: Add faculty colors
 
 //Dark Mode
-.fau-portal-menu.is-style-dark {
-	background-color: var(--FAU-Col-FAU-Blau-100);
+.is-style-dark {
 
-	.fau-portal-item .fau-portal-wrapper .fau-portal-content {
+	.fau-portal-menu {
 		background-color: var(--FAU-Col-FAU-Blau-100);
 
-		ul li a::before {
-			background-image: var(--icon-arrow-weiss);
-		}
+		.fau-portal-item .fau-portal-wrapper .fau-portal-content {
+			background-color: var(--FAU-Col-FAU-Blau-100);
 
-		> a span {
-			background-color: var(--FAU-Col-FAU-Dunkelblau-12_5);
+			ul li a::before {
+				background-image: var(--icon-arrow-weiss);
+			}
 
-			&::before {
-				background-image: var(--icon-arrow-fau-blau);
+			> a span {
+				background-color: var(--FAU-Col-FAU-Dunkelblau-12_5);
+
+				&::before {
+					background-image: var(--icon-arrow-fau-blau);
+				}
 			}
 		}
 	}

--- a/components/blocks/fau-portalmenu/style.scss
+++ b/components/blocks/fau-portalmenu/style.scss
@@ -3,3 +3,6 @@
  */
 
 /* Portal Menu styles will be implemented here */
+.fau-portal-item {
+    background-color: red;
+}

--- a/components/blocks/fau-portalmenu/style.scss
+++ b/components/blocks/fau-portalmenu/style.scss
@@ -3,6 +3,148 @@
  */
 
 /* Portal Menu styles will be implemented here */
-.fau-portal-item {
-    background-color: red;
+
+@use "../../ui/mixins/mixins" as *;
+
+.fau-portal-menu {
+	display: grid;
+	grid-template-columns: repeat(3, 1fr);
+	gap: var(--Spacing-8x);
+	max-width: var(--wide-max-width);
+	margin: 0 auto;
+	padding: var(--Spacing-10x);
+
+	.fau-portal-item {
+		display: flex;
+		align-items: center;
+		flex-direction: column;
+
+		.fau-portal-thumbnail {
+			width: 100%;
+
+			img {
+				aspect-ratio: 3/2;
+				object-fit: cover;
+				width: 100%;
+				height: 100%;
+			}
+		}
+
+		.fau-portal-wrapper {
+			position: relative;
+			bottom: var(--Spacing-10x);
+			width: 90%;
+
+			.fau-portal-content {
+				padding: var(--Spacing-4x) 0 var(--Spacing-4x) var(--Spacing-6x);
+				background-color: var(--FAU-Col-FAU-Weiss-100);
+
+				a {
+					text-decoration: none;
+					letter-spacing: var(--letter-spacing-big);
+				}
+
+				> a {
+					display: flex;
+					justify-content: space-between;
+					align-items: center;
+
+					h3 {
+						margin: 0;
+					}
+
+					span {
+						position: relative;
+						display: block;
+						padding: 0;
+						height: 2.5rem;
+						width: 2.5rem;
+						border-radius: 0;
+						background-color: var(--FAU-Col-FAU-Blau-100);
+
+						&::before {
+							content: "";
+							position: absolute;
+							top: calc(50% - 0.375rem);
+							top: calc(50% - 0.375rem);
+							left: calc(50% - 0.5rem);
+							width: 1rem;
+							height: 0.75rem;
+							background-image: var(--icon-arrow-weiss);
+							background-repeat: no-repeat;
+							transition: all 0.2s linear;
+						}
+					}
+
+					&:hover,
+					&:focus-visible {
+
+						span::before {
+							left: calc(50% - 0.3rem);
+						}
+					}
+				}
+
+				ul {
+					display: flex;
+					flex-direction: column;
+					gap: 1rem;
+					padding-left: unset;
+					list-style: none;
+					margin: var(--Spacing-6x) 0 0 0;
+
+					li {
+
+						a {
+							position: relative;
+
+							&::before {
+								content: "";
+								position: absolute;
+								top: calc(50% - 0.375rem);
+								right: -1.6rem;
+								width: 1rem;
+								height: 0.75rem;
+								background-image: var(--icon-arrow-fau-blau);
+								background-repeat: no-repeat;
+								color: var(--FAU-Col-FAU-Blau-100);
+								transition: all 0.2s ease-in-out;
+								border-left: 1rem solid transparent;
+							}
+
+							&:hover,
+							&:focus-visible {
+
+								&::before {
+									right: -1.8rem;
+								}
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+
+// Responsive
+@media screen and (max-width: 999px) {
+
+	.fau-portal-menu {
+		grid-template-columns: repeat(2, 1fr);
+	}
+}
+
+@include respond-to("small") {
+
+	.fau-portal-menu {
+		grid-template-columns: 1fr;
+	}
+}
+
+@include respond-to("x-small") {
+
+	.fau-portal-menu {
+		padding: var(--Spacing-5x);
+	}
 }

--- a/components/templates/portal-page/portal-page.php
+++ b/components/templates/portal-page/portal-page.php
@@ -34,14 +34,8 @@ if (!$menu_name) {
 }
 
 // Get display options
-$display_type = get_post_meta(get_the_ID(), 'portal_menu_type', true) ?: 1;
-$columns = 3; // Always use 3 columns
 $show_subs = !get_post_meta(get_the_ID(), 'portal_menu_hide_subs', true);
-$list_view = get_post_meta(get_the_ID(), 'portal_menu_list_view', true) ?: false;
 $no_thumbs = get_post_meta(get_the_ID(), 'portal_menu_hide_thumbs', true) ?: false;
-$no_fallback = get_post_meta(get_the_ID(), 'portal_menu_no_fallback', true) ?: false;
-$hover_zoom = get_post_meta(get_the_ID(), 'portal_menu_hover_zoom', true) ?: false;
-$hover_blur = get_post_meta(get_the_ID(), 'portal_menu_hover_blur', true) ?: false;
 $is_dark = get_post_meta(get_the_ID(), 'portal_menu_is_dark', true) ?: false;
 ?>
 
@@ -65,18 +59,10 @@ $is_dark = get_post_meta(get_the_ID(), 'portal_menu_is_dark', true) ?: false;
         if ($menu_name) {
             $shortcode = '[portalmenu';
             $shortcode .= ' menu="' . esc_attr($menu_name) . '"';
-            $shortcode .= ' type="' . intval($display_type) . '"';
-            $shortcode .= ' columns="' . intval($columns) . '"';
             $shortcode .= ' showsubs="' . ($show_subs ? 'true' : 'false') . '"';
-            $shortcode .= ' listview="' . ($list_view ? 'true' : 'false') . '"';
             $shortcode .= ' nothumbs="' . ($no_thumbs ? 'true' : 'false') . '"';
-            $shortcode .= ' nofallback="' . ($no_fallback ? 'true' : 'false') . '"';
-            $shortcode .= ' hoverzoom="' . ($hover_zoom ? 'true' : 'false') . '"';
-            $shortcode .= ' hoverblur="' . ($hover_blur ? 'true' : 'false') . '"';
-            $shortcode .= ' is-style-dark="' . ($is_dark ? 'true' : 'false') . '"';
+            $shortcode .= ' theme="' . ($is_dark ? 'dark' : 'light') . '"';
             $shortcode .= ']';
-            
-         
             
             // Output the shortcode
             echo do_shortcode($shortcode);

--- a/components/ui/editor/editor.scss
+++ b/components/ui/editor/editor.scss
@@ -37,21 +37,6 @@ html :where(.editor-styles-wrapper) {
 	margin-bottom: var(--Spacing-4x);
 }
 
-/* Portal Menu Settings */
-#fau_elemental_portal_menu_settings {
-	border: 2px solid #2271b1;
-	box-shadow: 0 0 5px rgba(34, 113, 177, 0.2);
-	margin-top: 10px;
-
-	.postbox-header {
-		background-color: #f0f6fc;
-	}
-
-	h2 {
-		font-weight: 700;
-	}
-}
-
 /* Fix metabox in Gutenberg */
 .components-panel__body .fau-portal-menu-settings {
 	padding: 16px;

--- a/components/ui/theme.scss
+++ b/components/ui/theme.scss
@@ -29,11 +29,15 @@
 @use "../core-blocks/tag-cloud/style" as *;
 @use "../core-blocks/verse/style" as *;
 
+// Blocks-Styles that are required outside of blocks
+@use "../blocks/fau-portalmenu/style.scss" as *;
+
 // Pattern Styles
 @use "../patterns/hero-fau/style" as *;
 @use "../patterns/hero-portal/style" as *;
 @use "../patterns/big-buttons-faculties/style" as *;
 @use "../patterns/big-buttons/style" as *;
+
 // Template Part Styles
 @use "../template-parts/breadcrumbs/style" as *;
 @use "../template-parts/footer-instance/style" as *;

--- a/inc/class-walker-content-menu.php
+++ b/inc/class-walker-content-menu.php
@@ -45,112 +45,55 @@ class Walker_Content_Menu extends Walker_Nav_Menu {
     }
 
     /**
-     * Start level output
-     */
-    public function start_lvl(&$output, $depth = 0, $args = array()) {
-        if (!$this->settings['showsubs']) {
-            return;
-        }
-
-        $indent = str_repeat("\t", $depth);
-        if ($this->settings['listview']) {
-            $output .= "\n$indent<ul class=\"portal-submenu\">\n";
-        } else {
-            $output .= "\n$indent<div class=\"portal-submenu\">\n";
-        }
-    }
-
-    /**
-     * End level output
-     */
-    public function end_lvl(&$output, $depth = 0, $args = array()) {
-        if (!$this->settings['showsubs']) {
-            return;
-        }
-
-        $indent = str_repeat("\t", $depth);
-        if ($this->settings['listview']) {
-            $output .= "$indent</ul>\n";
-        } else {
-            $output .= "$indent</div>\n";
-        }
-    }
-
-    /**
      * Start element output
      */
     public function start_el(&$output, $item, $depth = 0, $args = array(), $id = 0) {
-        $indent = ($depth) ? str_repeat("\t", $depth) : '';
+        $indent = str_repeat("\t", $depth + 1);
+
+        /*if (!$this->settings['showsubs'] && $depth !== 0) {
+            return;
+        }*/
         
         // Get menu item details
         $title = apply_filters('the_title', $item->title, $item->ID);
         $permalink = !empty($item->url) ? $item->url : '';
         
-        // Generate item classes
-        $classes = empty($item->classes) ? array() : (array) $item->classes;
-        $classes[] = 'menu-item-' . $item->ID;
-        
-        // Thumbnail/image handling
-        $thumbnail = '';
-        $thumbnail_id = get_post_thumbnail_id($item->object_id);
-        
-        if (!$this->settings['nothumbs'] && $depth === 0) {
-            if ($thumbnail_id) {
-                $img_src = wp_get_attachment_image_src($thumbnail_id, 'medium');
-                $thumbnail = $img_src ? $img_src[0] : false;
-            }
-        }
-        
         // Start element based on depth
-        if ($depth === 0) {
-            // Parent item (top level) - Proper semantic structure
-            $column_class = 'portal-column-' . $this->settings['columns'];
-            $type_class = 'portal-type-' . $this->settings['type'];
-            $has_thumbnail = ($thumbnail && !$this->settings['nothumbs']) ? 'has-thumbnail' : 'no-thumbnail';
-            
-            // Define theme and faculty classes properly
-            $theme_class = isset($this->settings['theme']) && $this->settings['theme'] === 'dark' ? 'portal-theme-dark' : 'portal-theme-light';
-            $faculty_class = !empty($this->settings['faculty_color']) ? 'portal-faculty-' . esc_attr($this->settings['faculty_color']) : '';
-            
-            $output .= $indent . '<li class="portal-item ' . $type_class . ' ' . $has_thumbnail . ' ' . $theme_class . ' ' . $faculty_class . ' ' . $column_class . ' fau-card">';
+        if ($depth === 0) {   
+            $output .= $indent . '<div class="fau-portal-item">' . "\n";
             
             // Image section
             if (!$this->settings['nothumbs']) {
-                $output .= '<div class="portal-thumbnail">';
-                $output .= '<a href="' . esc_url($permalink) . '" class="image-link" aria-label="' . esc_attr(sprintf(__('Go to %s', 'fau-elemental'), $title)) . '">';
+                $thumbnail = false;
+                $thumbnail_id = get_post_thumbnail_id($item->object_id);
+                if ($thumbnail_id) {
+                    $img_src = wp_get_attachment_image_src($thumbnail_id, 'medium');
+                    $thumbnail = $img_src ? $img_src[0] : false;
+                }
+
+                $output .= $indent . "\t" . '<div class="fau-portal-thumbnail">';
                 if ($thumbnail) {
                     $output .= '<img src="' . esc_url($thumbnail) . '" alt="' . esc_attr(sprintf(__('Featured image for %s', 'fau-elemental'), $title)) . '" loading="lazy">';
                 } else {
-                    // WCAG compliant placeholder with proper alt text
-                    $output .= '<div class="portal-placeholder-image" role="img" aria-label="' . esc_attr(sprintf(__('No image available for %s', 'fau-elemental'), $title)) . '">';
-                    $output .= '<span>' . __('No Image', 'fau-elemental') . '</span>';
-                    $output .= '</div>';
+                    $output .= '<img src="' . esc_url(get_template_directory_uri() . '/assets/images/logo.svg') . '" alt="' . esc_attr(sprintf(__('No image available for %s', 'fau-elemental'), $title)). '" loading="lazy">';
                 }
-                $output .= '</a>';
-                $output .= '</div>';
+                $output .= "</div>\n";
             }
             
             // Content section
-            $output .= '<div class="portal-content">';
+            $output .= $indent . "\t" . '<div class="fau-portal-wrapper"><div class="fau-portal-content">' . "\n";
             
             // Use proper heading hierarchy (h3 for portal items)
-            $output .= '<h3 class="portal-title">';
-            $output .= '<a href="' . esc_url($permalink) . '" class="portal-main-link" aria-label="' . esc_attr(sprintf(__('Go to main page: %s', 'fau-elemental'), $title)) . '">';
+            $output .= $indent . "\t\t";
+            $output .= '<a href="' . esc_url($permalink) . '" aria-label="' . esc_attr(sprintf(__('Go to %s', 'fau-elemental'), $title)) . '">';
+            $output .= '<h3>';
             $output .= esc_html($title);
-            $output .= '</a>';
-            $output .= '</h3>';
-            
-            // Start submenu list if we have children and subs are enabled
-            if ($this->settings['showsubs']) {
-                $output .= '<div class="portal-submenu" role="list">';
-            }
+            $output .= "</h3><span></span></a>\n";
         } else {
             // Child items (sublinks) - Simple list items with proper ARIA
-            $output .= $indent . '<div class="portal-subitem" role="listitem">';
-            $output .= '<a href="' . esc_url($permalink) . '" class="portal-sublink" aria-label="' . esc_attr(sprintf(__('Go to %s', 'fau-elemental'), $title)) . '">';
-            $output .= '<span class="portal-link-text">' . esc_html($title) . '</span>';
-            $output .= '<span class="portal-link-button" aria-hidden="true"></span>';
-            $output .= '</a>';
+            $output .= $indent . "\t\t<li>\n";
+            $output .= $indent . "\t\t\t" . '<a href="' . esc_url($permalink) . '" aria-label="' . esc_attr(sprintf(__('Go to %s', 'fau-elemental'), $title)) . '">';
+            $output .= esc_html($title) . "</a>\n";
         }
     }
 
@@ -158,17 +101,39 @@ class Walker_Content_Menu extends Walker_Nav_Menu {
      * End element output
      */
     public function end_el(&$output, $item, $depth = 0, $args = array()) {
+        $indent = str_repeat("\t", $depth + 1);
+
         if ($depth === 0) {
             // Parent item (top level)
-            if ($this->settings['showsubs']) {
-                $output .= '</div>'; // Close .portal-content
-                $output .= '</div>'; // Close .portal-submenu
-            }
-            $output .= "</li>\n"; // Close .portal-item
+            $output .= $indent . "\t</div></div>\n";
+            $output .= $indent . "</div>\n";
         } else {
             // Child items (sublinks)
-            $output .= "</div>\n";
-            $output .= "</li>\n";
+            $output .= $indent . "\t\t</li>\n";
         }
+    }
+
+    /**
+     * Start level output
+     */
+    public function start_lvl(&$output, $depth = 0, $args = array()) {
+        /*if (!$this->settings['showsubs']) {
+            return;
+        }*/
+
+        $indent = str_repeat("\t", $depth + 3);
+        $output .= "$indent<ul>\n";
+    }
+
+    /**
+     * End level output
+     */
+    public function end_lvl(&$output, $depth = 0, $args = array()) {
+        /*if (!$this->settings['showsubs']) {
+            return;
+        }*/
+
+        $indent = str_repeat("\t", $depth + 3);
+        $output .= "$indent</ul>\n";
     }
 } 

--- a/inc/class-walker-content-menu.php
+++ b/inc/class-walker-content-menu.php
@@ -19,17 +19,8 @@ class Walker_Content_Menu extends Walker_Nav_Menu {
      * Default settings for content menu
      */
     protected $defaults = array(
-        'type' => 1,        // Display type (1: 2:1 ratio, 2: 3:2 ratio, 3: 3:4 ratio)
-        'showsubs' => true, // Whether to show submenus
-        'listview' => false, // Whether to use list view
-        'nothumbs' => false, // Whether to hide thumbnails
-        'nofallback' => false, // Whether to skip fallback images
-        'hoverzoom' => false, // Whether to use hover zoom effect
-        'hoverblur' => false, // Whether to use hover blur effect
-        'theme' => 'light',  // Theme: light, dark
-        'faculty_color' => '', // Faculty color: phil, med, nat, tf, rw, default is none
-        'meganav' => false, // Whether to use mega navigation
-        'columns' => 3,     // Default number of columns
+        'showsubs' => true,     // Whether to show submenus
+        'nothumbs' => false,    // Whether to hide thumbnails
     );
 
     /**
@@ -50,9 +41,9 @@ class Walker_Content_Menu extends Walker_Nav_Menu {
     public function start_el(&$output, $item, $depth = 0, $args = array(), $id = 0) {
         $indent = str_repeat("\t", $depth + 1);
 
-        /*if (!$this->settings['showsubs'] && $depth !== 0) {
+        if (!$this->settings['showsubs'] && $depth !== 0) {
             return;
-        }*/
+        }
         
         // Get menu item details
         $title = apply_filters('the_title', $item->title, $item->ID);
@@ -117,9 +108,9 @@ class Walker_Content_Menu extends Walker_Nav_Menu {
      * Start level output
      */
     public function start_lvl(&$output, $depth = 0, $args = array()) {
-        /*if (!$this->settings['showsubs']) {
+        if (!$this->settings['showsubs']) {
             return;
-        }*/
+        }
 
         $indent = str_repeat("\t", $depth + 3);
         $output .= "$indent<ul>\n";
@@ -129,9 +120,9 @@ class Walker_Content_Menu extends Walker_Nav_Menu {
      * End level output
      */
     public function end_lvl(&$output, $depth = 0, $args = array()) {
-        /*if (!$this->settings['showsubs']) {
+        if (!$this->settings['showsubs']) {
             return;
-        }*/
+        }
 
         $indent = str_repeat("\t", $depth + 3);
         $output .= "$indent</ul>\n";

--- a/inc/portal-menu-compatibility.php
+++ b/inc/portal-menu-compatibility.php
@@ -324,14 +324,6 @@ function fau_elemental_portalmenu_shortcode($atts) {
     $hide_subs = filter_var($atts['nosub'] ?: $atts['hidesubs'], FILTER_VALIDATE_BOOLEAN);
     $is_dark = filter_var($atts['is-style-dark'] ?: $atts['dark'], FILTER_VALIDATE_BOOLEAN);
     
-    // Setup CSS classes using configuration
-    $menu_classes = 'fau-portal-menu';
-    
-    // Add optional classes using configuration
-    if ($is_dark) {
-        $menu_classes .= ' is-style-dark';
-    }
-    
     // Load our menu walker class
     if (!class_exists('Walker_Content_Menu')) {
         require_once get_template_directory() . '/inc/class-walker-content-menu.php';
@@ -343,7 +335,8 @@ function fau_elemental_portalmenu_shortcode($atts) {
     // Buffer the output and return it
     ob_start();
 
-    echo '<div class="' . $menu_classes . '" role="navigation" aria-label="' . __('Portal Menu', 'fau-elemental') . '">' . "\n";
+    echo '<div class="wp-block-group' . ($is_dark ? ' is-style-dark' : '') . '">' . "\n";
+    echo '<div class="fau-portal-menu" role="navigation" aria-label="' . __('Portal Menu', 'fau-elemental') . '">' . "\n";
 
     wp_nav_menu([
         'menu' => $menu_id,
@@ -359,7 +352,7 @@ function fau_elemental_portalmenu_shortcode($atts) {
         ]),
     ]);
     
-    echo '</div>';
+    echo '</div></div>';
     
     return ob_get_clean();
 }

--- a/inc/portal-menu-compatibility.php
+++ b/inc/portal-menu-compatibility.php
@@ -63,11 +63,6 @@ function fau_elemental_check_old_portal_menu_settings() {
                 // Get additional settings
                 if ($meta_key === 'portalmenu-slug') {
                     // Bottom menu settings
-                    $meganav = get_post_meta($post_id, 'fauval_portalmenu_meganav', true);
-                    if ($meganav) {
-                        update_post_meta($post_id, 'portal_menu_mega_nav', true);
-                    }
-                    
                     $nosub = get_post_meta($post_id, 'fauval_portalmenu_nosub', true);
                     if ($nosub) {
                         update_post_meta($post_id, 'portal_menu_hide_subs', true);
@@ -76,36 +71,6 @@ function fau_elemental_check_old_portal_menu_settings() {
                     $nothumbs = get_post_meta($post_id, 'fauval_portalmenu_thumbnailson', true);
                     if ($nothumbs) {
                         update_post_meta($post_id, 'portal_menu_hide_thumbs', true);
-                    }
-                    
-                    $nofallback = get_post_meta($post_id, 'fauval_portalmenu_nofallbackthumb', true);
-                    if ($nofallback) {
-                        update_post_meta($post_id, 'portal_menu_no_fallback', true);
-                    }
-                    
-                    $type = get_post_meta($post_id, 'fauval_portalmenu_type', true);
-                    if ($type) {
-                        update_post_meta($post_id, 'portal_menu_type', intval($type));
-                    }
-                    
-                    $listview = get_post_meta($post_id, 'fauval_portalmenu_listview', true);
-                    if ($listview) {
-                        update_post_meta($post_id, 'portal_menu_list_view', true);
-                    }
-                    
-                    $hoverzoom = get_post_meta($post_id, 'fauval_portalmenu_hoverZoom', true);
-                    if ($hoverzoom) {
-                        update_post_meta($post_id, 'portal_menu_hover_zoom', true);
-                    }
-                    
-                    $hoverblur = get_post_meta($post_id, 'fauval_portalmenu_hoverBlur', true);
-                    if ($hoverblur) {
-                        update_post_meta($post_id, 'portal_menu_hover_blur', true);
-                    }
-                    
-                    // Set default columns if not set
-                    if (!get_post_meta($post_id, 'portal_menu_columns', true)) {
-                        update_post_meta($post_id, 'portal_menu_columns', 3); // Default to 3 columns
                     }
                 } else {
                     // Top menu settings
@@ -117,36 +82,6 @@ function fau_elemental_check_old_portal_menu_settings() {
                     $nothumbs = get_post_meta($post_id, 'fauval_portalmenu_thumbnailson_oben', true);
                     if ($nothumbs) {
                         update_post_meta($post_id, 'portal_menu_hide_thumbs', true);
-                    }
-                    
-                    $nofallback = get_post_meta($post_id, 'fauval_portalmenu_nofallbackthumb_oben', true);
-                    if ($nofallback) {
-                        update_post_meta($post_id, 'portal_menu_no_fallback', true);
-                    }
-                    
-                    $type = get_post_meta($post_id, 'fauval_portalmenu_type_oben', true);
-                    if ($type) {
-                        update_post_meta($post_id, 'portal_menu_type', intval($type));
-                    }
-                    
-                    $listview = get_post_meta($post_id, 'fauval_portalmenu_listview_oben', true);
-                    if ($listview) {
-                        update_post_meta($post_id, 'portal_menu_list_view', true);
-                    }
-                    
-                    $hoverzoom = get_post_meta($post_id, 'fauval_portalmenu_hoverZoom_oben', true);
-                    if ($hoverzoom) {
-                        update_post_meta($post_id, 'portal_menu_hover_zoom', true);
-                    }
-                    
-                    $hoverblur = get_post_meta($post_id, 'fauval_portalmenu_hoverBlur_oben', true);
-                    if ($hoverblur) {
-                        update_post_meta($post_id, 'portal_menu_hover_blur', true);
-                    }
-                    
-                    // Set default columns if not set
-                    if (!get_post_meta($post_id, 'portal_menu_columns', true)) {
-                        update_post_meta($post_id, 'portal_menu_columns', 3); // Default to 3 columns
                     }
                 }
                 
@@ -210,41 +145,12 @@ function fau_elemental_check_content_for_old_shortcodes($post_id) {
                         error_log("Set portal_menu_id to {$menu_obj->term_id} for post $post_id from shortcode");
                         
                         // Handle other attributes
-                        if (isset($atts['type'])) {
-                            update_post_meta($post_id, 'portal_menu_type', intval($atts['type']));
-                        }
-                        
-                        if (isset($atts['columns'])) {
-                            update_post_meta($post_id, 'portal_menu_columns', intval($atts['columns']));
-                        }
-                        
                         if (isset($atts['showsubs']) && ($atts['showsubs'] === 'false' || $atts['showsubs'] === false)) {
                             update_post_meta($post_id, 'portal_menu_hide_subs', true);
                         }
                         
-                        if (isset($atts['listview']) && ($atts['listview'] === 'true' || $atts['listview'] === true)) {
-                            update_post_meta($post_id, 'portal_menu_list_view', true);
-                        }
-                        
                         if (isset($atts['nothumbs']) && ($atts['nothumbs'] === 'true' || $atts['nothumbs'] === true)) {
                             update_post_meta($post_id, 'portal_menu_hide_thumbs', true);
-                        }
-                        
-                        if (isset($atts['nofallback']) && ($atts['nofallback'] === 'true' || $atts['nofallback'] === true)) {
-                            update_post_meta($post_id, 'portal_menu_no_fallback', true);
-                        }
-                        
-                        if (isset($atts['hoverzoom']) && ($atts['hoverzoom'] === 'true' || $atts['hoverzoom'] === true)) {
-                            update_post_meta($post_id, 'portal_menu_hover_zoom', true);
-                        }
-                        
-                        if (isset($atts['hoverblur']) && ($atts['hoverblur'] === 'true' || $atts['hoverblur'] === true)) {
-                            update_post_meta($post_id, 'portal_menu_hover_blur', true);
-                        }
-                        
-                        // Set default columns if not already set
-                        if (!get_post_meta($post_id, 'portal_menu_columns', true)) {
-                            update_post_meta($post_id, 'portal_menu_columns', 3);
                         }
                     }
                 }
@@ -290,14 +196,6 @@ function fau_elemental_handle_portal_page_save($post_id) {
     $template = get_post_meta($post_id, '_wp_page_template', true);
     if ($template === FAU_Elemental_Portal_Menu_Config::TEMPLATE || $template === 'portal-page.php') {
         error_log("Post $post_id is using portal page template: $template");
-        
-        // Ensure default settings are set if not already
-        if (!get_post_meta($post_id, 'portal_menu_type', true)) {
-            update_post_meta($post_id, 'portal_menu_type', 1); // Default to Type 1
-        }
-        if (!get_post_meta($post_id, 'portal_menu_columns', true)) {
-            update_post_meta($post_id, 'portal_menu_columns', 3); // Default to 3 columns
-        }
     } else if (!empty($menu_id)) {
         // This page has portal menu settings but is not using the portal template
         error_log("Post $post_id has portal menu ID $menu_id but is not using portal template");
@@ -312,8 +210,6 @@ function fau_elemental_remigrate_portal_menus() {
     delete_option('fau_elemental_portal_menu_migrated');
     fau_elemental_check_old_portal_menu_settings();
 }
-
-
 
 /**
  * AJAX handler for remigration button
@@ -353,21 +249,13 @@ function fau_elemental_portalmenu_shortcode($atts) {
     $defaults = [
         'menu' => '',
         'id' => '',
-        'type' => FAU_Elemental_Portal_Menu_Config::get_default('type'),
-        'columns' => FAU_Elemental_Portal_Menu_Config::get_default('columns'),
         'nothumbs' => FAU_Elemental_Portal_Menu_Config::get_default('hide_thumbs'),
         'nothumbnails' => FAU_Elemental_Portal_Menu_Config::get_default('hide_thumbs'),
-        'nofallback' => FAU_Elemental_Portal_Menu_Config::get_default('no_fallback'),
-        'nofallbackthumb' => FAU_Elemental_Portal_Menu_Config::get_default('no_fallback'),
         'nosub' => !FAU_Elemental_Portal_Menu_Config::get_default('show_subs'),
         'hidesubs' => !FAU_Elemental_Portal_Menu_Config::get_default('show_subs'),
-        'listview' => FAU_Elemental_Portal_Menu_Config::get_default('list_view'),
-        'hoverzoom' => FAU_Elemental_Portal_Menu_Config::get_default('hover_zoom'),
-        'hoverZoom' => FAU_Elemental_Portal_Menu_Config::get_default('hover_zoom'),
-        'hoverblur' => FAU_Elemental_Portal_Menu_Config::get_default('hover_blur'),
-        'hoverBlur' => FAU_Elemental_Portal_Menu_Config::get_default('hover_blur'),
         'is-style-dark' => FAU_Elemental_Portal_Menu_Config::get_default('is_dark'),
         'dark' => FAU_Elemental_Portal_Menu_Config::get_default('is_dark'),
+        'theme' => FAU_Elemental_Portal_Menu_Config::get_default('is_dark') ? "dark" : "light",
     ];
     
     $atts = shortcode_atts($defaults, $atts, 'portalmenu');
@@ -433,36 +321,15 @@ function fau_elemental_portalmenu_shortcode($atts) {
     
     // Handle boolean attributes that might have different formats
     $hide_thumbs = filter_var($atts['nothumbs'] ?: $atts['nothumbnails'], FILTER_VALIDATE_BOOLEAN);
-    $no_fallback = filter_var($atts['nofallback'] ?: $atts['nofallbackthumb'], FILTER_VALIDATE_BOOLEAN);
     $hide_subs = filter_var($atts['nosub'] ?: $atts['hidesubs'], FILTER_VALIDATE_BOOLEAN);
-    $list_view = filter_var($atts['listview'], FILTER_VALIDATE_BOOLEAN);
-    $hover_zoom = filter_var($atts['hoverzoom'] ?: $atts['hoverZoom'], FILTER_VALIDATE_BOOLEAN);
-    $hover_blur = filter_var($atts['hoverblur'] ?: $atts['hoverBlur'], FILTER_VALIDATE_BOOLEAN);
     $is_dark = filter_var($atts['is-style-dark'] ?: $atts['dark'], FILTER_VALIDATE_BOOLEAN);
     
     // Setup CSS classes using configuration
-    $menu_classes = FAU_Elemental_Portal_Menu_Config::get_css_class('container');
-    
-    // Add type-specific class
-    $type = intval($atts['type']);
-    $type_config = FAU_Elemental_Portal_Menu_Config::get_type($type);
-    $menu_classes .= ' ' . $type_config['css_class'];
+    $menu_classes = 'fau-portal-menu';
     
     // Add optional classes using configuration
-    if ($list_view) {
-        $menu_classes .= ' ' . FAU_Elemental_Portal_Menu_Config::get_css_class('list_view');
-    }
-    if ($hide_thumbs) {
-        $menu_classes .= ' ' . FAU_Elemental_Portal_Menu_Config::get_css_class('no_thumb');
-    }
-    if ($hover_zoom) {
-        $menu_classes .= ' ' . FAU_Elemental_Portal_Menu_Config::get_css_class('hover_zoom');
-    }
-    if ($hover_blur) {
-        $menu_classes .= ' ' . FAU_Elemental_Portal_Menu_Config::get_css_class('hover_blur');
-    }
     if ($is_dark) {
-        $menu_classes .= ' ' . FAU_Elemental_Portal_Menu_Config::get_css_class('dark_style');
+        $menu_classes .= ' is-style-dark';
     }
     
     // Load our menu walker class
@@ -475,41 +342,24 @@ function fau_elemental_portalmenu_shortcode($atts) {
     
     // Buffer the output and return it
     ob_start();
-    
-    // Semantic HTML with proper ARIA attributes
-    echo '<section class="portal-menu-shortcode" aria-labelledby="portal-menu-shortcode-heading">';
-    
-    // Hidden heading for screen readers
-    if ($menu_obj) {
-        echo '<h2 id="portal-menu-shortcode-heading" class="' . esc_attr(FAU_Elemental_Portal_Menu_Config::get_css_class('screen_reader_text')) . '">';
-        echo esc_html(sprintf(
-            /* translators: %s: Menu name */
-            __('Portal Menu: %s', 'fau-elemental'),
-            $menu_obj->name
-        ));
-        echo '</h2>';
-    }
-    
-    echo '<nav class="' . esc_attr($menu_classes) . '" aria-label="' . esc_attr__('Portal Menu', 'fau-elemental') . '">';
-    
+
+    echo '<div class="' . $menu_classes . '" role="navigation" aria-label="' . __('Portal Menu', 'fau-elemental') . '">' . "\n";
+
     wp_nav_menu([
         'menu' => $menu_id,
-        'container' => false,
-        'menu_class' => FAU_Elemental_Portal_Menu_Config::get_css_class('menu_list'),
+        'echo' => true,
+        'container' => true,
+        'items_wrap' => '%3$s',
+        'link_before' => '',
+        'link_after' => '',
+        'item_spacing' => 'discard',
         'walker' => new Walker_Content_Menu([
-            'columns' => intval($atts['columns']),
             'showsubs' => !$hide_subs,
             'nothumbs' => $hide_thumbs,
-            'nofallback' => $no_fallback,
-            'listview' => $list_view,
-            'hoverzoom' => $hover_zoom,
-            'hoverblur' => $hover_blur,
-            'type' => $type,
         ]),
     ]);
     
-    echo '</nav>';
-    echo '</section>';
+    echo '</div>';
     
     return ob_get_clean();
 }
@@ -560,54 +410,19 @@ function fau_elemental_migrate_portal_menu_settings($post_id) {
         
         // Migrate other settings based on which menu we're using
         $settings_map = array(
-            'type' => $is_top_menu ? 'fauval_portalmenu_type_oben' : 'fauval_portalmenu_type',
             'thumbnails' => $is_top_menu ? 'fauval_portalmenu_thumbnailson_oben' : 'fauval_portalmenu_thumbnailson',
-            'nofallback' => $is_top_menu ? 'fauval_portalmenu_nofallbackthumb_oben' : 'fauval_portalmenu_nofallbackthumb',
             'nosub' => $is_top_menu ? 'fauval_portalmenu_nosub_oben' : 'fauval_portalmenu_nosub',
-            'listview' => $is_top_menu ? 'fauval_portalmenu_listview_oben' : 'fauval_portalmenu_listview',
-            'hoverzoom' => $is_top_menu ? 'fauval_portalmenu_hoverZoom_oben' : 'fauval_portalmenu_hoverZoom',
-            'hoverblur' => $is_top_menu ? 'fauval_portalmenu_hoverBlur_oben' : 'fauval_portalmenu_hoverBlur'
         );
         
         // Process each setting
-        $type = get_post_meta($post_id, $settings_map['type'], true);
-        if ($type) {
-            update_post_meta($post_id, 'portal_menu_type', intval($type));
-        }
-        
         $thumbnails = get_post_meta($post_id, $settings_map['thumbnails'], true);
         if ($thumbnails) {
             update_post_meta($post_id, 'portal_menu_hide_thumbs', true);
         }
         
-        $nofallback = get_post_meta($post_id, $settings_map['nofallback'], true);
-        if ($nofallback) {
-            update_post_meta($post_id, 'portal_menu_no_fallback', true);
-        }
-        
         $nosub = get_post_meta($post_id, $settings_map['nosub'], true);
         if ($nosub) {
             update_post_meta($post_id, 'portal_menu_hide_subs', true);
-        }
-        
-        $listview = get_post_meta($post_id, $settings_map['listview'], true);
-        if ($listview) {
-            update_post_meta($post_id, 'portal_menu_list_view', true);
-        }
-        
-        $hoverzoom = get_post_meta($post_id, $settings_map['hoverzoom'], true);
-        if ($hoverzoom) {
-            update_post_meta($post_id, 'portal_menu_hover_zoom', true);
-        }
-        
-        $hoverblur = get_post_meta($post_id, $settings_map['hoverblur'], true);
-        if ($hoverblur) {
-            update_post_meta($post_id, 'portal_menu_hover_blur', true);
-        }
-        
-        // Set default columns if not set
-        if (!get_post_meta($post_id, 'portal_menu_columns', true)) {
-            update_post_meta($post_id, 'portal_menu_columns', 3);
         }
         
         // Check if the page is using a custom template

--- a/inc/portal-menu-config.php
+++ b/inc/portal-menu-config.php
@@ -27,86 +27,9 @@ class FAU_Elemental_Portal_Menu_Config {
      * Default portal menu settings
      */
     const DEFAULTS = [
-        'type' => 1,
-        'columns' => 3,
         'show_subs' => true,
         'hide_thumbs' => false,
-        'no_fallback' => false,
-        'list_view' => false,
-        'hover_zoom' => false,
-        'hover_blur' => false,
         'is_dark' => false,
-        'is_mega_nav' => false,
-    ];
-    
-    /**
-     * Portal menu display types
-     */
-    const TYPES = [
-        1 => [
-            'name' => 'type_1_2_1_ratio',
-            'label' => 'Type 1 (2:1 Ratio)',
-            'aspect_ratio' => '2/1',
-            'css_class' => 'size_2-1'
-        ],
-        2 => [
-            'name' => 'type_2_3_2_ratio',
-            'label' => 'Type 2 (3:2 Ratio)',
-            'aspect_ratio' => '3/2',
-            'css_class' => 'size_3-2'
-        ],
-        3 => [
-            'name' => 'type_3_3_4_ratio',
-            'label' => 'Type 3 (3:4 Ratio)',
-            'aspect_ratio' => '3/4',
-            'css_class' => 'size_3-4'
-        ]
-    ];
-    
-    /**
-     * Column options
-     */
-    const COLUMNS = [
-        1 => [
-            'label' => '1 Column',
-            'css_class' => 'portal-column-1'
-        ],
-        2 => [
-            'label' => '2 Columns',
-            'css_class' => 'portal-column-2'
-        ],
-        3 => [
-            'label' => '3 Columns',
-            'css_class' => 'portal-column-3'
-        ],
-        4 => [
-            'label' => '4 Columns',
-            'css_class' => 'portal-column-4'
-        ]
-    ];
-    
-    /**
-     * CSS class names
-     */
-    const CSS_CLASSES = [
-        'container' => 'contentmenu',
-        'menu_list' => 'subpages-menu',
-        'portal_item' => 'portal-item',
-        'portal_thumbnail' => 'portal-thumbnail',
-        'portal_content' => 'portal-content',
-        'portal_title' => 'portal-title',
-        'portal_main_link' => 'portal-main-link',
-        'portal_button_arrow' => 'portal-button-arrow',
-        'portal_submenu' => 'portal-submenu',
-        'portal_subitem' => 'portal-subitem',
-        'portal_sublink' => 'portal-sublink',
-        'screen_reader_text' => 'screen-reader-text',
-        'image_link' => 'image-link',
-        'list_view' => 'listview',
-        'no_thumb' => 'no-thumb',
-        'hover_zoom' => 'hover-zoom',
-        'hover_blur' => 'hover-blur',
-        'dark_style' => 'is-style-dark'
     ];
     
     /**
@@ -114,14 +37,8 @@ class FAU_Elemental_Portal_Menu_Config {
      */
     const META_FIELDS = [
         'menu_id' => 'portal_menu_id',
-        'type' => 'portal_menu_type',
-        'columns' => 'portal_menu_columns',
         'hide_subs' => 'portal_menu_hide_subs',
-        'list_view' => 'portal_menu_list_view',
         'hide_thumbs' => 'portal_menu_hide_thumbs',
-        'no_fallback' => 'portal_menu_no_fallback',
-        'hover_zoom' => 'portal_menu_hover_zoom',
-        'hover_blur' => 'portal_menu_hover_blur',
         'is_dark' => 'portal_menu_is_dark'
     ];
     
@@ -133,36 +50,6 @@ class FAU_Elemental_Portal_Menu_Config {
      */
     public static function get_default($key) {
         return self::DEFAULTS[$key] ?? null;
-    }
-    
-    /**
-     * Get type configuration
-     *
-     * @param int $type The type number
-     * @return array The type configuration
-     */
-    public static function get_type($type) {
-        return self::TYPES[$type] ?? self::TYPES[1];
-    }
-    
-    /**
-     * Get column configuration
-     *
-     * @param int $columns The column number
-     * @return array The column configuration
-     */
-    public static function get_column($columns) {
-        return self::COLUMNS[$columns] ?? self::COLUMNS[3];
-    }
-    
-    /**
-     * Get CSS class
-     *
-     * @param string $element The element name
-     * @return string The CSS class
-     */
-    public static function get_css_class($element) {
-        return self::CSS_CLASSES[$element] ?? '';
     }
     
     /**

--- a/inc/portal-page-settings.php
+++ b/inc/portal-page-settings.php
@@ -34,14 +34,8 @@ function fau_elemental_portal_menu_meta_box_callback($post) {
 
     // Get the saved values
     $menu_id = get_post_meta($post->ID, 'portal_menu_id', true);
-    $display_type = get_post_meta($post->ID, 'portal_menu_type', true) ?: 1;
-    $columns = 3; // Always use 3 columns
     $hide_subs = get_post_meta($post->ID, 'portal_menu_hide_subs', true);
-    $list_view = get_post_meta($post->ID, 'portal_menu_list_view', true);
     $hide_thumbs = get_post_meta($post->ID, 'portal_menu_hide_thumbs', true);
-    $no_fallback = get_post_meta($post->ID, 'portal_menu_no_fallback', true);
-    $hover_zoom = get_post_meta($post->ID, 'portal_menu_hover_zoom', true);
-    $hover_blur = get_post_meta($post->ID, 'portal_menu_hover_blur', true);
     $is_dark = get_post_meta($post->ID, 'portal_menu_is_dark', true);
 
     // Get all menus
@@ -62,22 +56,8 @@ function fau_elemental_portal_menu_meta_box_callback($post) {
         </p>
         
         <p>
-            <label for="portal_menu_type"><strong><?php esc_html_e('Display Type', 'fau-elemental'); ?>:</strong></label>
-            <select name="portal_menu_type" id="portal_menu_type" class="widefat">
-                <option value="1" <?php selected($display_type, 1); ?>><?php esc_html_e('Type 1 (2:1 Ratio)', 'fau-elemental'); ?></option>
-                <option value="2" <?php selected($display_type, 2); ?>><?php esc_html_e('Type 2 (3:2 Ratio)', 'fau-elemental'); ?></option>
-                <option value="3" <?php selected($display_type, 3); ?>><?php esc_html_e('Type 3 (3:4 Ratio)', 'fau-elemental'); ?></option>
-            </select>
-        </p>
-        
-        <p>
             <label><input type="checkbox" name="portal_menu_hide_subs" id="portal_menu_hide_subs" value="1" <?php checked($hide_subs, true); ?>>
             <?php esc_html_e('Hide Submenus', 'fau-elemental'); ?></label>
-        </p>
-        
-        <p>
-            <label><input type="checkbox" name="portal_menu_list_view" id="portal_menu_list_view" value="1" <?php checked($list_view, true); ?>>
-            <?php esc_html_e('List View', 'fau-elemental'); ?></label>
         </p>
         
         <p>
@@ -86,31 +66,11 @@ function fau_elemental_portal_menu_meta_box_callback($post) {
         </p>
         
         <p>
-            <label><input type="checkbox" name="portal_menu_no_fallback" id="portal_menu_no_fallback" value="1" <?php checked($no_fallback, true); ?>>
-            <?php esc_html_e('No Fallback Image', 'fau-elemental'); ?></label>
-        </p>
-        
-        <h4><?php esc_html_e('Hover Effects', 'fau-elemental'); ?></h4>
-        <p>
-            <label><input type="checkbox" name="portal_menu_hover_zoom" id="portal_menu_hover_zoom" value="1" <?php checked($hover_zoom, true); ?>>
-            <?php esc_html_e('Zoom', 'fau-elemental'); ?></label>
-        </p>
-        
-        <p>
-            <label><input type="checkbox" name="portal_menu_hover_blur" id="portal_menu_hover_blur" value="1" <?php checked($hover_blur, true); ?>>
-            <?php esc_html_e('Blur', 'fau-elemental'); ?></label>
-        </p>
-        
-        <h4><?php esc_html_e('Appearance', 'fau-elemental'); ?></h4>
-        <p>
             <label><input type="checkbox" name="portal_menu_is_dark" id="portal_menu_is_dark" value="1" <?php checked($is_dark, true); ?>>
             <?php esc_html_e('Dark Style', 'fau-elemental'); ?></label>
         </p>
         
-        <div class="portal-menu-shortcode-example" style="margin-top: 15px; padding-top: 15px; border-top: 1px solid #ddd;">
-            <h4><?php esc_html_e('Shortcode Usage', 'fau-elemental'); ?></h4>
-            <code>[portalmenu menu="<?php echo ($menu_id ? esc_attr($menu_id) : 'menu-id-or-name'); ?>" type="<?php echo esc_attr($display_type); ?>" columns="<?php echo esc_attr($columns) ?>"]</code>
-        </div>
+        <code>[portalmenu menu="<?php echo ($menu_id ? esc_attr($menu_id) : 'menu-id-or-name'); ?>" showsubs="<?php echo esc_attr($hide_subs ? "false" : "true"); ?>" nothumbs="<?php echo esc_attr($hide_thumbs ? "true" : "false") ?>"]</code>
     </div>
     <?php
 }
@@ -144,22 +104,10 @@ function fau_elemental_save_portal_menu_meta_box_data($post_id) {
         update_post_meta($post_id, 'portal_menu_id', sanitize_text_field($_POST['portal_menu_id']));
     }
 
-    // Save display type
-    if (isset($_POST['portal_menu_type'])) {
-        update_post_meta($post_id, 'portal_menu_type', intval($_POST['portal_menu_type']));
-    }
-    
-    // Always save 3 columns
-    update_post_meta($post_id, 'portal_menu_columns', 3);
-
     // Save checkboxes
     $checkbox_fields = array(
         'portal_menu_hide_subs',
-        'portal_menu_list_view',
         'portal_menu_hide_thumbs',
-        'portal_menu_no_fallback',
-        'portal_menu_hover_zoom',
-        'portal_menu_hover_blur',
         'portal_menu_is_dark'
     );
 
@@ -171,4 +119,5 @@ function fau_elemental_save_portal_menu_meta_box_data($post_id) {
         }
     }
 }
+
 add_action('save_post', 'fau_elemental_save_portal_menu_meta_box_data'); 

--- a/inc/shortcodes.php
+++ b/inc/shortcodes.php
@@ -52,152 +52,145 @@ class FAU_Elemental_Shortcodes {
             ), 
         $atts);
 
-        $out = '';
-
         // Normalize menu parameter - could be an ID, slug, or name
         $menu = $atts['menu'] ? esc_attr($atts['menu']) : '';
         $error = '<p>' . __("No menu could be found with the specified name", 'fau-elemental') . '</p>';
         $error .= "name=$menu";
-        
-        if (!empty($menu)) {
-            // Get default options from theme
-            $global_hoverzoom = isset($fau_elemental_options['portalmenus_hover_zoom']) ? $fau_elemental_options['portalmenus_hover_zoom'] : false;
-            $global_hoverzoom = filter_var($global_hoverzoom, FILTER_VALIDATE_BOOLEAN);
-            $global_hoverblur = isset($fau_elemental_options['portalmenus_hover_blur']) ? $fau_elemental_options['portalmenus_hover_blur'] : false;
-            $global_hoverblur = filter_var($global_hoverblur, FILTER_VALIDATE_BOOLEAN);
 
-            // Convert string attributes to boolean
-            $atts['meganav'] = is_bool($atts['meganav']) ? $atts['meganav'] : ($atts['meganav'] === 'true' || $atts['meganav'] === '1');
-            $atts['showsubs'] = is_bool($atts['showsubs']) ? $atts['showsubs'] : ($atts['showsubs'] === 'true' || $atts['showsubs'] === '1');
-            $atts['nothumbs'] = is_bool($atts['nothumbs']) ? $atts['nothumbs'] : ($atts['nothumbs'] === 'true' || $atts['nothumbs'] === '1');
-            $atts['nofallback'] = is_bool($atts['nofallback']) ? $atts['nofallback'] : ($atts['nofallback'] === 'true' || $atts['nofallback'] === '1');
-            $atts['listview'] = is_bool($atts['listview']) ? $atts['listview'] : ($atts['listview'] === 'true' || $atts['listview'] === '1');
-            $atts['hoverzoom'] = is_bool($atts['hoverzoom']) ? $atts['hoverzoom'] : ($atts['hoverzoom'] === 'true' || $atts['hoverzoom'] === '1');
-            $atts['hoverblur'] = is_bool($atts['hoverblur']) ? $atts['hoverblur'] : ($atts['hoverblur'] === 'true' || $atts['hoverblur'] === '1');
-            
-            $meganav = $atts['meganav'];
-            $listview = $atts['listview'];
-            $showsubs = $atts['showsubs'];
-            $nothumbs = $atts['nothumbs'];
-            $nofallback = $atts['nofallback'];
-            $hoverzoom = $atts['hoverzoom'] ? $atts['hoverzoom'] : $global_hoverzoom;
-            $hoverblur = $atts['hoverblur'] ? $atts['hoverblur'] : $global_hoverblur;
-            $type = intval($atts['type']);
-            $columns = intval($atts['columns']) ?: 3;
-
-            // Find menu by ID, slug, or name
-            $term = null;
-            if (is_numeric($menu)) {
-                $term = wp_get_nav_menu_object($menu);
-            } else {
-                // Try by slug first, then by name
-                $term = get_term_by('slug', $menu, 'nav_menu');
-                if (!$term) {
-                    $term = get_term_by('name', $menu, 'nav_menu');
-                }
-            }
-            
-            if (!$term) {
-                return $error;
-            }
-            
-            $slug = $term->slug;
-            $subentries = isset($fau_elemental_options['default_submenu_entries']) ? $fau_elemental_options['default_submenu_entries'] : 5;
-            
-            if ($showsubs === false) {
-                $subentries = 0;
-            }
-
-            $a_contentmenuclasses = array('contentmenu');
-            $thumbnail = 'medium';
-
-            switch ($type) {
-                case 1:
-                    $thumbnail = 'medium';
-                    $a_contentmenuclasses[] = 'size_2-1';
-                    break;
-                case 2:
-                    $a_contentmenuclasses[] = 'size_3-2';
-                    $thumbnail = 'full';
-                    break;
-                case 3:
-                    $a_contentmenuclasses[] = 'size_3-4';
-                    $thumbnail = 'full';
-                    break;
-                default:
-                    $thumbnail = 'medium';
-                    $type = 1;
-                    $a_contentmenuclasses[] = 'size_2-1';
-                    break;
-            }
-
-            // Add classes based on options
-            if ($meganav) {
-                $a_contentmenuclasses[] = 'meganav';
-            }
-            if (!$showsubs) {
-                $a_contentmenuclasses[] = 'no-sub';
-            }
-            if ($nofallback) {
-                $a_contentmenuclasses[] = 'no-fallback';
-            }
-            if ($nothumbs) {
-                $a_contentmenuclasses[] = 'no-thumb';
-            }
-            if ($listview) {
-                $a_contentmenuclasses[] = 'listview';
-            }
-            if ($hoverzoom) {
-                $a_contentmenuclasses[] = 'hover-zoom';
-            }
-            if ($hoverblur) {
-                $a_contentmenuclasses[] = 'hover-blur';
-            }
-            
-            // Include Walker_Content_Menu class if not already included
-            if (!class_exists('Walker_Content_Menu')) {
-                require_once get_template_directory() . '/inc/class-walker-content-menu.php';
-            }
-            
-            $out .= '<div class="' . implode(' ', $a_contentmenuclasses) . '" role="navigation" aria-label="' . __('Content Menu', 'fau-elemental') . '">';
-            
-            // Set up walker settings
-            $walker_settings = array(
-                'type' => $type,
-                'showsubs' => $showsubs,
-                'listview' => $listview,
-                'nothumbs' => $nothumbs,
-                'nofallback' => $nofallback,
-                'hoverzoom' => $hoverzoom,
-                'hoverblur' => $hoverblur,
-                'columns' => $columns
-            );
-            
-            // Generate menu HTML
-            $outnav = wp_nav_menu(
-                array(
-                    'menu' => $slug,
-                    'echo' => false,
-                    'container' => true,
-                    'items_wrap' => '%3$s',
-                    'link_before' => '',
-                    'link_after' => '',
-                    'item_spacing' => 'discard',
-                    'walker' => new Walker_Content_Menu($walker_settings)
-                )
-            );
-            
-            if ($listview) {
-                $out .= $outnav;
-            } else {
-                $out .= '<ul class="subpages-menu">';
-                $out .= $outnav;
-                $out .= '</ul>';
-            }
-            $out .= '</div>';
-        } else {
-            $out = $error;
+        if (empty($menu)) {
+            return $error;
         }
+
+        // Get default options from theme
+        $global_hoverzoom = isset($fau_elemental_options['portalmenus_hover_zoom']) ? $fau_elemental_options['portalmenus_hover_zoom'] : false;
+        $global_hoverzoom = filter_var($global_hoverzoom, FILTER_VALIDATE_BOOLEAN);
+        $global_hoverblur = isset($fau_elemental_options['portalmenus_hover_blur']) ? $fau_elemental_options['portalmenus_hover_blur'] : false;
+        $global_hoverblur = filter_var($global_hoverblur, FILTER_VALIDATE_BOOLEAN);
+
+        // Convert string attributes to boolean
+        $atts['meganav'] = is_bool($atts['meganav']) ? $atts['meganav'] : ($atts['meganav'] === 'true' || $atts['meganav'] === '1');
+        $atts['showsubs'] = is_bool($atts['showsubs']) ? $atts['showsubs'] : ($atts['showsubs'] === 'true' || $atts['showsubs'] === '1');
+        $atts['nothumbs'] = is_bool($atts['nothumbs']) ? $atts['nothumbs'] : ($atts['nothumbs'] === 'true' || $atts['nothumbs'] === '1');
+        $atts['nofallback'] = is_bool($atts['nofallback']) ? $atts['nofallback'] : ($atts['nofallback'] === 'true' || $atts['nofallback'] === '1');
+        $atts['listview'] = is_bool($atts['listview']) ? $atts['listview'] : ($atts['listview'] === 'true' || $atts['listview'] === '1');
+        $atts['hoverzoom'] = is_bool($atts['hoverzoom']) ? $atts['hoverzoom'] : ($atts['hoverzoom'] === 'true' || $atts['hoverzoom'] === '1');
+        $atts['hoverblur'] = is_bool($atts['hoverblur']) ? $atts['hoverblur'] : ($atts['hoverblur'] === 'true' || $atts['hoverblur'] === '1');
+        
+        $meganav = $atts['meganav'];
+        $listview = $atts['listview'];
+        $showsubs = $atts['showsubs'];
+        $nothumbs = $atts['nothumbs'];
+        $nofallback = $atts['nofallback'];
+        $hoverzoom = $atts['hoverzoom'] ? $atts['hoverzoom'] : $global_hoverzoom;
+        $hoverblur = $atts['hoverblur'] ? $atts['hoverblur'] : $global_hoverblur;
+        $type = intval($atts['type']);
+        $columns = intval($atts['columns']) ?: 3;
+
+        // Find menu by ID, slug, or name
+        $term = null;
+        if (is_numeric($menu)) {
+            $term = wp_get_nav_menu_object($menu);
+        } else {
+            // Try by slug first, then by name
+            $term = get_term_by('slug', $menu, 'nav_menu');
+            if (!$term) {
+                $term = get_term_by('name', $menu, 'nav_menu');
+            }
+        }
+        
+        if (!$term) {
+            return $error;
+        }
+        
+        $slug = $term->slug;
+        $subentries = isset($fau_elemental_options['default_submenu_entries']) ? $fau_elemental_options['default_submenu_entries'] : 5;
+        
+        if ($showsubs === false) {
+            $subentries = 0;
+        }
+
+        $a_contentmenuclasses = array('contentmenu');
+        $thumbnail = 'medium';
+
+        switch ($type) {
+            case 1:
+                $thumbnail = 'medium';
+                $a_contentmenuclasses[] = 'size_2-1';
+                break;
+            case 2:
+                $a_contentmenuclasses[] = 'size_3-2';
+                $thumbnail = 'full';
+                break;
+            case 3:
+                $a_contentmenuclasses[] = 'size_3-4';
+                $thumbnail = 'full';
+                break;
+            default:
+                $thumbnail = 'medium';
+                $type = 1;
+                $a_contentmenuclasses[] = 'size_2-1';
+                break;
+        }
+
+        // Add classes based on options
+        if ($meganav) {
+            $a_contentmenuclasses[] = 'meganav';
+        }
+        if (!$showsubs) {
+            $a_contentmenuclasses[] = 'no-sub';
+        }
+        if ($nofallback) {
+            $a_contentmenuclasses[] = 'no-fallback';
+        }
+        if ($nothumbs) {
+            $a_contentmenuclasses[] = 'no-thumb';
+        }
+        if ($listview) {
+            $a_contentmenuclasses[] = 'listview';
+        }
+        if ($hoverzoom) {
+            $a_contentmenuclasses[] = 'hover-zoom';
+        }
+        if ($hoverblur) {
+            $a_contentmenuclasses[] = 'hover-blur';
+        }
+        
+        // Include Walker_Content_Menu class if not already included
+        if (!class_exists('Walker_Content_Menu')) {
+            require_once get_template_directory() . '/inc/class-walker-content-menu.php';
+        }
+        
+        // Set up walker settings
+        $walker_settings = array(
+            'type' => $type,
+            'showsubs' => $showsubs,
+            'listview' => $listview,
+            'nothumbs' => $nothumbs,
+            'nofallback' => $nofallback,
+            'hoverzoom' => $hoverzoom,
+            'hoverblur' => $hoverblur,
+            'columns' => $columns
+        );
+        
+        $out = "\n\n\n<!------------------- PORTAL ------------------>\n";
+        $out .= '<div class="' . implode(' ', $a_contentmenuclasses) . '" role="navigation" aria-label="' . __('Content Menu', 'fau-elemental') . '">' . "\n";
+        
+        // Generate menu HTML
+        $out .= wp_nav_menu(
+            array(
+                'menu' => $slug,
+                'echo' => false,
+                'container' => true,
+                'items_wrap' => '%3$s',
+                'link_before' => '',
+                'link_after' => '',
+                'item_spacing' => 'discard',
+                'walker' => new Walker_Content_Menu($walker_settings)
+            )
+        );
+
+        $out .= "</div>\n";
+        $out .= "\n<!------------- PORTAL END ---------------->\n\n\n";
         
         return $out;
     }

--- a/inc/shortcodes.php
+++ b/inc/shortcodes.php
@@ -34,21 +34,13 @@ class FAU_Elemental_Shortcodes {
      * @param string $content Shortcode content
      * @return string HTML output
      */
-    function fau_portalmenu($atts, $content = null) {
-        global $fau_elemental_options;
-        
+    function fau_portalmenu($atts, $content = null) {        
         $atts = shortcode_atts(
             array(
-                'menu' => '',
-                'meganav' => false,
+                'menu'     => '',
                 'showsubs' => true,
                 'nothumbs' => false,
-                'nofallback' => false,
-                'type' => 1,
-                'columns' => 3,
-                'listview' => false,
-                'hoverzoom' => false,
-                'hoverblur' => false,
+                'theme'    => 'light', // Theme: light, dark
             ), 
         $atts);
 
@@ -61,30 +53,10 @@ class FAU_Elemental_Shortcodes {
             return $error;
         }
 
-        // Get default options from theme
-        $global_hoverzoom = isset($fau_elemental_options['portalmenus_hover_zoom']) ? $fau_elemental_options['portalmenus_hover_zoom'] : false;
-        $global_hoverzoom = filter_var($global_hoverzoom, FILTER_VALIDATE_BOOLEAN);
-        $global_hoverblur = isset($fau_elemental_options['portalmenus_hover_blur']) ? $fau_elemental_options['portalmenus_hover_blur'] : false;
-        $global_hoverblur = filter_var($global_hoverblur, FILTER_VALIDATE_BOOLEAN);
-
-        // Convert string attributes to boolean
-        $atts['meganav'] = is_bool($atts['meganav']) ? $atts['meganav'] : ($atts['meganav'] === 'true' || $atts['meganav'] === '1');
-        $atts['showsubs'] = is_bool($atts['showsubs']) ? $atts['showsubs'] : ($atts['showsubs'] === 'true' || $atts['showsubs'] === '1');
-        $atts['nothumbs'] = is_bool($atts['nothumbs']) ? $atts['nothumbs'] : ($atts['nothumbs'] === 'true' || $atts['nothumbs'] === '1');
-        $atts['nofallback'] = is_bool($atts['nofallback']) ? $atts['nofallback'] : ($atts['nofallback'] === 'true' || $atts['nofallback'] === '1');
-        $atts['listview'] = is_bool($atts['listview']) ? $atts['listview'] : ($atts['listview'] === 'true' || $atts['listview'] === '1');
-        $atts['hoverzoom'] = is_bool($atts['hoverzoom']) ? $atts['hoverzoom'] : ($atts['hoverzoom'] === 'true' || $atts['hoverzoom'] === '1');
-        $atts['hoverblur'] = is_bool($atts['hoverblur']) ? $atts['hoverblur'] : ($atts['hoverblur'] === 'true' || $atts['hoverblur'] === '1');
-        
-        $meganav = $atts['meganav'];
-        $listview = $atts['listview'];
-        $showsubs = $atts['showsubs'];
-        $nothumbs = $atts['nothumbs'];
-        $nofallback = $atts['nofallback'];
-        $hoverzoom = $atts['hoverzoom'] ? $atts['hoverzoom'] : $global_hoverzoom;
-        $hoverblur = $atts['hoverblur'] ? $atts['hoverblur'] : $global_hoverblur;
-        $type = intval($atts['type']);
-        $columns = intval($atts['columns']) ?: 3;
+        // Convert attribute types
+        $showsubs = is_bool($atts['showsubs']) ? $atts['showsubs'] : ($atts['showsubs'] === 'true' || $atts['showsubs'] === '1');
+        $nothumbs = is_bool($atts['nothumbs']) ? $atts['nothumbs'] : ($atts['nothumbs'] === 'true' || $atts['nothumbs'] === '1');
+        $theme = $atts['theme'] === 'dark' ? 'dark' : 'light';
 
         // Find menu by ID, slug, or name
         $term = null;
@@ -103,56 +75,11 @@ class FAU_Elemental_Shortcodes {
         }
         
         $slug = $term->slug;
-        $subentries = isset($fau_elemental_options['default_submenu_entries']) ? $fau_elemental_options['default_submenu_entries'] : 5;
-        
-        if ($showsubs === false) {
-            $subentries = 0;
-        }
-
-        $a_contentmenuclasses = array('contentmenu');
-        $thumbnail = 'medium';
-
-        switch ($type) {
-            case 1:
-                $thumbnail = 'medium';
-                $a_contentmenuclasses[] = 'size_2-1';
-                break;
-            case 2:
-                $a_contentmenuclasses[] = 'size_3-2';
-                $thumbnail = 'full';
-                break;
-            case 3:
-                $a_contentmenuclasses[] = 'size_3-4';
-                $thumbnail = 'full';
-                break;
-            default:
-                $thumbnail = 'medium';
-                $type = 1;
-                $a_contentmenuclasses[] = 'size_2-1';
-                break;
-        }
+        $portal_classes = array('fau-portal-menu');
 
         // Add classes based on options
-        if ($meganav) {
-            $a_contentmenuclasses[] = 'meganav';
-        }
-        if (!$showsubs) {
-            $a_contentmenuclasses[] = 'no-sub';
-        }
-        if ($nofallback) {
-            $a_contentmenuclasses[] = 'no-fallback';
-        }
-        if ($nothumbs) {
-            $a_contentmenuclasses[] = 'no-thumb';
-        }
-        if ($listview) {
-            $a_contentmenuclasses[] = 'listview';
-        }
-        if ($hoverzoom) {
-            $a_contentmenuclasses[] = 'hover-zoom';
-        }
-        if ($hoverblur) {
-            $a_contentmenuclasses[] = 'hover-blur';
+        if ($theme === 'dark') {
+            $portal_classes[] = 'is-style-dark';
         }
         
         // Include Walker_Content_Menu class if not already included
@@ -162,18 +89,12 @@ class FAU_Elemental_Shortcodes {
         
         // Set up walker settings
         $walker_settings = array(
-            'type' => $type,
             'showsubs' => $showsubs,
-            'listview' => $listview,
             'nothumbs' => $nothumbs,
-            'nofallback' => $nofallback,
-            'hoverzoom' => $hoverzoom,
-            'hoverblur' => $hoverblur,
-            'columns' => $columns
         );
         
-        $out = "\n\n\n<!------------------- PORTAL ------------------>\n";
-        $out .= '<div class="' . implode(' ', $a_contentmenuclasses) . '" role="navigation" aria-label="' . __('Content Menu', 'fau-elemental') . '">' . "\n";
+        $out = "\n";
+        $out .= '<div class="' . implode(' ', $portal_classes) . '" role="navigation" aria-label="' . __('Portal Menu', 'fau-elemental') . '">' . "\n";
         
         // Generate menu HTML
         $out .= wp_nav_menu(
@@ -190,8 +111,7 @@ class FAU_Elemental_Shortcodes {
         );
 
         $out .= "</div>\n";
-        $out .= "\n<!------------- PORTAL END ---------------->\n\n\n";
-        
+
         return $out;
     }
 }

--- a/inc/shortcodes.php
+++ b/inc/shortcodes.php
@@ -75,13 +75,7 @@ class FAU_Elemental_Shortcodes {
         }
         
         $slug = $term->slug;
-        $portal_classes = array('fau-portal-menu');
 
-        // Add classes based on options
-        if ($theme === 'dark') {
-            $portal_classes[] = 'is-style-dark';
-        }
-        
         // Include Walker_Content_Menu class if not already included
         if (!class_exists('Walker_Content_Menu')) {
             require_once get_template_directory() . '/inc/class-walker-content-menu.php';
@@ -94,7 +88,8 @@ class FAU_Elemental_Shortcodes {
         );
         
         $out = "\n";
-        $out .= '<div class="' . implode(' ', $portal_classes) . '" role="navigation" aria-label="' . __('Portal Menu', 'fau-elemental') . '">' . "\n";
+        $out .= '<div class="wp-block-group' . ($theme === 'dark' ? ' is-style-dark' : '') . '">' . "\n";
+        $out .= '<div class="fau-portal-menu" role="navigation" aria-label="' . __('Portal Menu', 'fau-elemental') . '">' . "\n";
         
         // Generate menu HTML
         $out .= wp_nav_menu(
@@ -110,7 +105,7 @@ class FAU_Elemental_Shortcodes {
             )
         );
 
-        $out .= "</div>\n";
+        $out .= "</div>\n</div>\n";
 
         return $out;
     }

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
  * Theme Name:        FAU-Elemental
  * Theme URI:         TBD - theme public web page
  * Description:       TBD - theme description
- * Version:           0.2.15
+ * Version:           0.2.16
  * Author:            TBD - theme author
  * Author URI:        TBD - theme author web page
  * Tags:              TBD - theme tags


### PR DESCRIPTION
This PR is a rework of the portalmenü. Lots of options were removed because they are not needed and they simplify the generated HTML. The only options supported now are Hide/Show Thumbnails, Hide/Show Submenus and Darkmode on/off.

Also a default thumbnail will be shown if thumbnails are enabled and the post or page has no thumbnail.

This PR also includes the styling.