### PR TITLE
[58] Portalmenü style and functionality fixes

### DIFF
--- a/components/blocks/fau-portalmenu/EditorPreview.jsx
+++ b/components/blocks/fau-portalmenu/EditorPreview.jsx
@@ -4,7 +4,6 @@
 import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 
-// TODO Get the theme URL from WordPress data
 const FALLBACK_IMAGE =
 	'/wp-content/themes/fau-elemental/assets/images/logo.svg';
 

--- a/components/blocks/fau-portalmenu/EditorPreview.jsx
+++ b/components/blocks/fau-portalmenu/EditorPreview.jsx
@@ -54,7 +54,7 @@ const EditorPreview = ( { attributes } ) => {
 							media.media_details.sizes
 						) {
 							const imageSize =
-								media.media_details.sizes.medium ||
+								media.media_details.sizes.medium_large ||
 								media.media_details.sizes.full;
 							if ( imageSize ) {
 								featuredImageUrl = imageSize.source_url;

--- a/components/blocks/fau-portalmenu/EditorPreview.jsx
+++ b/components/blocks/fau-portalmenu/EditorPreview.jsx
@@ -166,7 +166,7 @@ const EditorPreview = ( { attributes } ) => {
 			__( 'Menu Item', 'fau-elemental' );
 
 		return (
-			<div key={ item.id } className="fau-portal-item">
+			<li key={ item.id } className="fau-portal-item">
 				{ ! attributes.noThumbs && (
 					<div className="fau-portal-thumbnail">
 						{ itemImage ? (
@@ -263,7 +263,7 @@ const EditorPreview = ( { attributes } ) => {
 						) }
 					</div>
 				</div>
-			</div>
+			</li>
 		);
 	};
 
@@ -278,7 +278,9 @@ const EditorPreview = ( { attributes } ) => {
 				aria-label={ __( 'Portal Menu', 'fau-elemental' ) }
 			>
 				{ menuItems && menuItems.length > 0 ? (
-					menuItems.map( ( item ) => renderMenuItem( item ) )
+					<ul>
+						{ menuItems.map( ( item ) => renderMenuItem( item ) ) }
+					</ul>
 				) : menuItems && menuItems.length === 0 ? (
 					<div
 						className="fau-portal-empty-state"

--- a/components/blocks/fau-portalmenu/EditorPreview.jsx
+++ b/components/blocks/fau-portalmenu/EditorPreview.jsx
@@ -5,7 +5,8 @@ import { __, sprintf } from '@wordpress/i18n';
 import { useSelect } from '@wordpress/data';
 
 const FALLBACK_IMAGE =
-	'/wp-content/themes/fau-elemental/assets/images/logo.svg';
+	( ( window.fauElemental && window.fauElemental.themeUrl ) ??
+		'/wp-content/themes/fau-elemental' ) + '/assets/images/logo.svg';
 
 /**
  * Editor preview component for FAU Portal Menu block

--- a/components/blocks/fau-portalmenu/block.json
+++ b/components/blocks/fau-portalmenu/block.json
@@ -34,6 +34,5 @@
 	},
 	"textdomain": "fau-elemental",
 	"editorScript": "file:./index.js",
-	"editorStyle": "file:./editor.css",
 	"render": "file:./render.php"
 }

--- a/components/blocks/fau-portalmenu/editor.scss
+++ b/components/blocks/fau-portalmenu/editor.scss
@@ -1,5 +1,0 @@
-/**
- * Editor styles for the FAU Portal Menu block
- */
-
-/* Portal Menu editor styles will be implemented here */

--- a/components/blocks/fau-portalmenu/render.php
+++ b/components/blocks/fau-portalmenu/render.php
@@ -57,7 +57,6 @@ wp_nav_menu([
     'menu' => $menu,
     'echo' => true,
     'container' => true,
-    'items_wrap' => '%3$s',
     'link_before' => '',
     'link_after' => '',
     'item_spacing' => 'discard',

--- a/components/blocks/fau-portalmenu/render.php
+++ b/components/blocks/fau-portalmenu/render.php
@@ -32,35 +32,11 @@ $show_subs = isset($attributes['showSubs']) ? !empty($attributes['showSubs']) : 
 $no_thumbs = isset($attributes['noThumbs']) ? !empty($attributes['noThumbs']) : FAU_Elemental_Portal_Menu_Config::get_default('hide_thumbs');
 $is_dark =   isset($attributes['isDark'])   ? !empty($attributes['isDark'])   : FAU_Elemental_Portal_Menu_Config::get_default('is_dark');
 
-// Create Walker instance with settings
-$walker = new Walker_Content_Menu([
+// Set up walker settings
+$walker_settings = array(
     'showsubs' => $show_subs,
     'nothumbs' => $no_thumbs,
-]);
+    'theme'    => $is_dark ? 'dark' : 'light',
+);
 
-// Get menu object for accessibility
-$menu_obj = null;
-if (is_numeric($menu)) {
-    $menu_obj = wp_get_nav_menu_object($menu);
-} else {
-    $menu_obj = get_term_by('name', $menu, 'nav_menu');
-    if (!$menu_obj) {
-        $menu_obj = get_term_by('slug', $menu, 'nav_menu');
-    }
-}
-
-echo '<div class="wp-block-group' . ($is_dark ? ' is-style-dark' : '') . '">' . "\n";
-echo '<div class="fau-portal-menu" role="navigation" aria-label="' . __('Portal Menu', 'fau-elemental') . '">' . "\n";
-
-// Render the menu
-wp_nav_menu([
-    'menu' => $menu,
-    'echo' => true,
-    'container' => true,
-    'link_before' => '',
-    'link_after' => '',
-    'item_spacing' => 'discard',
-    'walker' => $walker
-]);
-
-echo '</div></div>';
+echo Walker_Content_Menu::render_portalmenu($menu, $walker_settings);

--- a/components/blocks/fau-portalmenu/style.scss
+++ b/components/blocks/fau-portalmenu/style.scss
@@ -7,6 +7,10 @@
 @use "../../ui/mixins/mixins" as *;
 
 .fau-portal-menu {
+	max-width: fit-content;
+}
+
+.fau-portal-menu > ul {
 	display: grid;
 	grid-template-columns: repeat(2, 1fr);
 	gap: 0 var(--Spacing-8x);
@@ -155,7 +159,7 @@
 //Dark Mode
 .is-style-dark {
 
-	.fau-portal-menu {
+	.fau-portal-menu > ul {
 		background-color: var(--FAU-Col-FAU-Blau-100);
 
 		.fau-portal-item .fau-portal-wrapper .fau-portal-content {
@@ -179,15 +183,15 @@
 // Responsive
 @media screen and (max-width: 999px) {
 
-	.fau-portal-menu:has(.fau-portal-thumbnail) {
+	.fau-portal-menu:has(.fau-portal-thumbnail) > ul {
 		grid-template-columns: repeat(2, 1fr);
 	}
 }
 
 @media screen and (max-width: 599px) {
 
-	.fau-portal-menu,
-	.fau-portal-menu:has(.fau-portal-thumbnail) {
+	.fau-portal-menu > ul,
+	.fau-portal-menu:has(.fau-portal-thumbnail) > ul {
 		grid-template-columns: 1fr;
 	}
 
@@ -198,7 +202,7 @@
 
 @include respond-to("x-small") {
 
-	.fau-portal-menu {
+	.fau-portal-menu > ul {
 		padding: var(--Spacing-5x);
 	}
 }

--- a/inc/class-walker-content-menu.php
+++ b/inc/class-walker-content-menu.php
@@ -58,7 +58,7 @@ class Walker_Content_Menu extends Walker_Nav_Menu {
                 $thumbnail = false;
                 $thumbnail_id = get_post_thumbnail_id($item->object_id);
                 if ($thumbnail_id) {
-                    $img_src = wp_get_attachment_image_src($thumbnail_id, 'medium');
+                    $img_src = wp_get_attachment_image_src($thumbnail_id, 'medium_large');
                     $thumbnail = $img_src ? $img_src[0] : false;
                 }
 

--- a/inc/class-walker-content-menu.php
+++ b/inc/class-walker-content-menu.php
@@ -94,6 +94,10 @@ class Walker_Content_Menu extends Walker_Nav_Menu {
     public function end_el(&$output, $item, $depth = 0, $args = array()) {
         $indent = str_repeat("\t", $depth + 1);
 
+        if (!$this->settings['showsubs'] && $depth !== 0) {
+            return;
+        }
+
         if ($depth === 0) {
             // Parent item (top level)
             $output .= $indent . "\t</div></div>\n";

--- a/inc/class-walker-content-menu.php
+++ b/inc/class-walker-content-menu.php
@@ -31,7 +31,7 @@ class Walker_Content_Menu extends Walker_Nav_Menu {
     /**
      * Constructor
      */
-    public function __construct($settings = array()) {
+    protected function __construct($settings = array()) {
         $this->settings = wp_parse_args($settings, $this->defaults);
     }
 
@@ -56,7 +56,7 @@ class Walker_Content_Menu extends Walker_Nav_Menu {
             // Image section
             if (!$this->settings['nothumbs']) {
                 $thumbnail = false;
-                $thumbnail_id = get_post_thumbnail_id($item->object_id);
+                $thumbnail_id = !empty($item->linked_post) ? get_post_thumbnail_id($item->linked_post) : false;
                 if ($thumbnail_id) {
                     $img_src = wp_get_attachment_image_src($thumbnail_id, 'medium_large');
                     $thumbnail = $img_src ? $img_src[0] : false;
@@ -130,5 +130,61 @@ class Walker_Content_Menu extends Walker_Nav_Menu {
 
         $indent = str_repeat("\t", $depth + 3);
         $output .= "$indent</ul>\n";
+    }
+
+    public static function render_portalmenu($slug, $settings = array()) {
+        $menu_items = wp_get_nav_menu_items($slug);
+        $post_ids = [];
+        foreach ($menu_items as $item) {
+            if ($item->menu_item_parent === 0 && ($item->object === 'page' || $item->object === 'post')) {
+                $post_ids[] = (int) $item->object_id;
+            }
+        }
+        _prime_post_caches($post_ids, false, true);
+
+        $query = new WP_Query([
+            'post__in' => $post_ids,
+            'post_type' => ['page', 'post'],
+            'post_status' => 'publish',
+            'nopaging' => true,
+        ]);
+        update_post_thumbnail_cache($query);
+
+        $linked_posts = [];
+        foreach ($query->posts as $post) {
+            $linked_posts[$post->ID] = $post;
+        }
+
+        $menu_filter = function ($items) use ($linked_posts) {
+            foreach ($items as $item) {
+                if (isset($linked_posts[$item->object_id])) {
+                    $item->linked_post = $linked_posts[$item->object_id];
+                }
+            }
+            return $items;
+        };
+
+        add_filter('wp_nav_menu_objects', $menu_filter);
+
+        // Generate menu HTML
+        $out = "\n";
+        $out .= '<div class="wp-block-group' . (($settings["theme"] ?? "") === 'dark' ? ' is-style-dark' : '') . '">' . "\n";
+        $out .= '<div class="fau-portal-menu" role="navigation" aria-label="' . __('Portal Menu', 'fau-elemental') . '">' . "\n";
+        $out .= wp_nav_menu(
+            array(
+                'menu' => $slug,
+                'echo' => false,
+                'container' => true,
+                'link_before' => '',
+                'link_after' => '',
+                'item_spacing' => 'discard',
+                'walker' => new Walker_Content_Menu($settings)
+            )
+        );
+        $out .= "</div>\n</div>\n";
+
+        remove_filter('wp_nav_menu_objects', $menu_filter);
+
+        return $out;
     }
 } 

--- a/inc/class-walker-content-menu.php
+++ b/inc/class-walker-content-menu.php
@@ -51,7 +51,7 @@ class Walker_Content_Menu extends Walker_Nav_Menu {
         
         // Start element based on depth
         if ($depth === 0) {   
-            $output .= $indent . '<div class="fau-portal-item">' . "\n";
+            $output .= $indent . '<li class="fau-portal-item">' . "\n";
             
             // Image section
             if (!$this->settings['nothumbs']) {
@@ -101,7 +101,7 @@ class Walker_Content_Menu extends Walker_Nav_Menu {
         if ($depth === 0) {
             // Parent item (top level)
             $output .= $indent . "\t</div></div>\n";
-            $output .= $indent . "</div>\n";
+            $output .= $indent . "</li>\n";
         } else {
             // Child items (sublinks)
             $output .= $indent . "\t\t</li>\n";

--- a/inc/portal-menu-compatibility.php
+++ b/inc/portal-menu-compatibility.php
@@ -328,32 +328,15 @@ function fau_elemental_portalmenu_shortcode($atts) {
     if (!class_exists('Walker_Content_Menu')) {
         require_once get_template_directory() . '/inc/class-walker-content-menu.php';
     }
-    
-    // Get menu object for accessibility
-    $menu_obj = wp_get_nav_menu_object($menu_id);
-    
-    // Buffer the output and return it
-    ob_start();
 
-    echo '<div class="wp-block-group' . ($is_dark ? ' is-style-dark' : '') . '">' . "\n";
-    echo '<div class="fau-portal-menu" role="navigation" aria-label="' . __('Portal Menu', 'fau-elemental') . '">' . "\n";
+    // Set up walker settings
+    $walker_settings = array(
+        'showsubs' => !$hide_subs,
+        'nothumbs' => $hide_thumbs,
+        'theme'    => $is_dark ? 'dark' : 'light',
+    );
 
-    wp_nav_menu([
-        'menu' => $menu_id,
-        'echo' => true,
-        'container' => true,
-        'link_before' => '',
-        'link_after' => '',
-        'item_spacing' => 'discard',
-        'walker' => new Walker_Content_Menu([
-            'showsubs' => !$hide_subs,
-            'nothumbs' => $hide_thumbs,
-        ]),
-    ]);
-    
-    echo '</div></div>';
-    
-    return ob_get_clean();
+    return Walker_Content_Menu::render_portalmenu($menu_id, $walker_settings);
 }
 add_shortcode('portalmenu', 'fau_elemental_portalmenu_shortcode');
 

--- a/inc/portal-menu-compatibility.php
+++ b/inc/portal-menu-compatibility.php
@@ -342,7 +342,6 @@ function fau_elemental_portalmenu_shortcode($atts) {
         'menu' => $menu_id,
         'echo' => true,
         'container' => true,
-        'items_wrap' => '%3$s',
         'link_before' => '',
         'link_after' => '',
         'item_spacing' => 'discard',

--- a/inc/portal-page-settings.php
+++ b/inc/portal-page-settings.php
@@ -9,6 +9,32 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+define('FAUE_NAV_MENUS_CACHE_KEY', 'fau_elemental_nav_menus');
+
+/**
+ * Returns cached menus
+ */
+function fau_elemental_get_nav_menus() {
+    $menus = wp_cache_get( FAUE_NAV_MENUS_CACHE_KEY, 'theme' );
+    if ( false === $menus ) {
+        $menus = get_terms(
+            array(
+                'taxonomy'   => 'nav_menu',
+                'fields'     => 'id=>name', // ID -> Name-Map
+                'hide_empty' => false,
+                'orderby'    => 'name',
+            )
+        );
+        wp_cache_set( FAUE_NAV_MENUS_CACHE_KEY, $menus, 'theme', 3 * HOUR_IN_SECONDS );
+    }
+    return $menus;
+}
+
+/**
+ * Clear cache on navigation menu change
+ */
+add_action( 'wp_update_nav_menu', fn() => wp_cache_delete( FAUE_NAV_MENUS_CACHE_KEY, 'theme' ) );
+
 /**
  * Add meta boxes for portal page settings
  */
@@ -33,13 +59,13 @@ function fau_elemental_portal_menu_meta_box_callback($post) {
     wp_nonce_field('fau_elemental_portal_menu_meta_box', 'fau_elemental_portal_menu_meta_box_nonce');
 
     // Get the saved values
-    $menu_id = get_post_meta($post->ID, 'portal_menu_id', true);
+    $selected_menu_id = get_post_meta($post->ID, 'portal_menu_id', true);
     $hide_subs = get_post_meta($post->ID, 'portal_menu_hide_subs', true);
     $hide_thumbs = get_post_meta($post->ID, 'portal_menu_hide_thumbs', true);
     $is_dark = get_post_meta($post->ID, 'portal_menu_is_dark', true);
 
     // Get all menus
-    $menus = wp_get_nav_menus();
+    $menus = fau_elemental_get_nav_menus();
 
     ?>
     <div class="fau-portal-menu-settings">
@@ -47,9 +73,9 @@ function fau_elemental_portal_menu_meta_box_callback($post) {
             <label for="portal_menu_id"><strong><?php esc_html_e('Menu', 'fau-elemental'); ?>:</strong></label>
             <select name="portal_menu_id" id="portal_menu_id" class="widefat">
                 <option value=""><?php esc_html_e('- Select Menu -', 'fau-elemental'); ?></option>
-                <?php foreach ($menus as $menu) : ?>
-                    <option value="<?php echo esc_attr($menu->term_id); ?>" <?php selected($menu_id, $menu->term_id); ?>>
-                        <?php echo esc_html($menu->name); ?>
+                <?php foreach ($menus as $menu_id => $menu_name) : ?>
+                    <option value="<?php echo esc_attr($menu_id); ?>" <?php selected($selected_menu_id, $menu_id); ?>>
+                        <?php echo esc_html($menu_name); ?>
                     </option>
                 <?php endforeach; ?>
             </select>
@@ -70,7 +96,7 @@ function fau_elemental_portal_menu_meta_box_callback($post) {
             <?php esc_html_e('Dark Style', 'fau-elemental'); ?></label>
         </p>
         
-        <code>[portalmenu menu="<?php echo ($menu_id ? esc_attr($menu_id) : 'menu-id-or-name'); ?>" showsubs="<?php echo esc_attr($hide_subs ? "false" : "true"); ?>" nothumbs="<?php echo esc_attr($hide_thumbs ? "true" : "false") ?>"]</code>
+        <code>[portalmenu menu="<?php echo ($selected_menu_id ? esc_attr($selected_menu_id) : 'menu-id-or-name'); ?>" showsubs="<?php echo esc_attr($hide_subs ? "false" : "true"); ?>" nothumbs="<?php echo esc_attr($hide_thumbs ? "true" : "false") ?>"]</code>
     </div>
     <?php
 }

--- a/inc/shortcodes.php
+++ b/inc/shortcodes.php
@@ -73,8 +73,6 @@ class FAU_Elemental_Shortcodes {
         if (!$term) {
             return $error;
         }
-        
-        $slug = $term->slug;
 
         // Include Walker_Content_Menu class if not already included
         if (!class_exists('Walker_Content_Menu')) {
@@ -85,28 +83,10 @@ class FAU_Elemental_Shortcodes {
         $walker_settings = array(
             'showsubs' => $showsubs,
             'nothumbs' => $nothumbs,
-        );
-        
-        $out = "\n";
-        $out .= '<div class="wp-block-group' . ($theme === 'dark' ? ' is-style-dark' : '') . '">' . "\n";
-        $out .= '<div class="fau-portal-menu" role="navigation" aria-label="' . __('Portal Menu', 'fau-elemental') . '">' . "\n";
-        
-        // Generate menu HTML
-        $out .= wp_nav_menu(
-            array(
-                'menu' => $slug,
-                'echo' => false,
-                'container' => true,
-                'link_before' => '',
-                'link_after' => '',
-                'item_spacing' => 'discard',
-                'walker' => new Walker_Content_Menu($walker_settings)
-            )
+            'theme'    => $theme,
         );
 
-        $out .= "</div>\n</div>\n";
-
-        return $out;
+        return Walker_Content_Menu::render_portalmenu($term->slug, $walker_settings);
     }
 }
 

--- a/inc/shortcodes.php
+++ b/inc/shortcodes.php
@@ -97,7 +97,6 @@ class FAU_Elemental_Shortcodes {
                 'menu' => $slug,
                 'echo' => false,
                 'container' => true,
-                'items_wrap' => '%3$s',
                 'link_before' => '',
                 'link_after' => '',
                 'item_spacing' => 'discard',


### PR DESCRIPTION
This PR aims to fix the problems found in the FAU review:

- Default Bilder werden im Editor nicht angezeigt (steht „No“ da)
- Lädt beim ersten Anlegen der Seite sehr lange bis die Menüs angezeigt werden, danach wird alles schnell angezeigt
- Vorschau/Beitrags-Bilder werden unscharf angezeigt
- Ungecachtes wp_get_nav_menus() führt zu extrem vielen DB-Queries
- Start-/End-Tag-Mismatch bei deaktivierten Submenus
- Keine Listen-Semantik – Ebene 0 ohne `<li>` / `<ul>`
- N + 1-Queries für Thumbnails

The comment "Pfeil-Icon muss Farbwert #04316A haben" will be fixed in a different PR by @danielboese as it is not directly related to the portalmenü.

The comment "Icons für externe Links ist noch falsch" required further communication with FAU and also affects other parts of the theme like links, because until now we just used target="blank" to detect external links. But the target attribute should not be used, so we need a new detection mechnism for all external links (maybe the start of the URL?)