### PR TITLE
[11] komponente big buttons pattern fix

### DIFF
--- a/components/blocks/fau-big-button/big-button.php
+++ b/components/blocks/fau-big-button/big-button.php
@@ -10,6 +10,9 @@ if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
+// Character limits for the big button block (matching frontend behavior)
+define('FAU_BIG_BUTTON_DESCRIPTION_MAX_LENGTH', 80); // Only descriptions are trimmed in frontend
+
 /**
  * Trim text by characters while respecting word boundaries
  *
@@ -137,7 +140,7 @@ function render_big_button_html($items, $options = []) {
                     </h3>
                     <?php if (!empty($excerpt)) : ?>
                         <p>
-                            <?php echo esc_html(fau_trim_text_big_button($excerpt, 80, '…')); ?>
+                            <?php echo esc_html(fau_trim_text_big_button($excerpt, FAU_BIG_BUTTON_DESCRIPTION_MAX_LENGTH, '…')); ?>
                         </p>
                     <?php endif; ?>
                     <span class="arrow-link" aria-hidden="true"></span>

--- a/components/blocks/fau-big-button/block.json
+++ b/components/blocks/fau-big-button/block.json
@@ -6,7 +6,7 @@
 	"title": "FAU Big Button",
 	"category": "fau-elemental/FAU",
 	"icon": "button",
-	"description": "Display a group of big buttons",
+	"description": "Display a group of big buttons with descriptions limited to 80 characters",
 	"supports": {
 		"html": false,
 		"className": true
@@ -76,8 +76,8 @@
 			"items": [
 				{
 					"id": 1,
-					"title": "Example Button",
-					"description": "This is an example description for the button.",
+					"title": "Student Services",
+					"description": "Access student services and support resources.",
 					"url": "#",
 					"facultyColor": "default"
 				}

--- a/components/blocks/fau-big-button/block.json
+++ b/components/blocks/fau-big-button/block.json
@@ -6,7 +6,7 @@
 	"title": "FAU Big Button",
 	"category": "fau-elemental/FAU",
 	"icon": "button",
-	"description": "Display a group of big buttons with descriptions limited to 80 characters",
+	"description": "Display a group of big buttons",
 	"supports": {
 		"html": false,
 		"className": true

--- a/components/blocks/fau-big-button/edit.js
+++ b/components/blocks/fau-big-button/edit.js
@@ -52,6 +52,9 @@ function trimTextSmart( text, maxChars = 80, more = '…' ) {
 	return result + more;
 }
 
+// Character limits for the big button block (matching frontend behavior)
+const DESCRIPTION_MAX_LENGTH = 80; // Only descriptions are trimmed in frontend
+
 /**
  * The edit function describes the structure of your block in the context of the
  * editor. This represents what the editor will render when the block is used.
@@ -324,11 +327,35 @@ export default function Edit( { attributes, setAttributes } ) {
 										)
 									}
 									rows={ 3 }
-									help={ __(
-										'You can also click on the description in the preview to edit it directly.',
-										'fau-elemental'
+									help={ sprintf(
+										/* translators: %d: maximum character count */
+										__(
+											'Maximum %d characters recommended. You can also click on the description in the preview to edit it directly.',
+											'fau-elemental'
+										),
+										DESCRIPTION_MAX_LENGTH
 									) }
 								/>
+								{ item.description && (
+									<p
+										className={ `fau-big-button-character-count ${
+											item.description.length >=
+											DESCRIPTION_MAX_LENGTH * 0.9
+												? 'fau-big-button-character-count--warning'
+												: ''
+										}` }
+									>
+										{ sprintf(
+											/* translators: %1$d: current character count, %2$d: maximum character count */
+											__(
+												'%1$d / %2$d characters',
+												'fau-elemental'
+											),
+											item.description.length,
+											DESCRIPTION_MAX_LENGTH
+										) }
+									</p>
+								) }
 								<TextControl
 									label={ __( 'URL', 'fau-elemental' ) }
 									value={ item.url || '' }
@@ -533,7 +560,17 @@ export default function Edit( { attributes, setAttributes } ) {
 								<RichText
 									tagName="p"
 									className="rich-text"
-									value={ item.description || '' }
+									value={
+										item.description &&
+										item.description.length >
+											DESCRIPTION_MAX_LENGTH
+											? trimTextSmart(
+													item.description,
+													DESCRIPTION_MAX_LENGTH,
+													'…'
+											  )
+											: item.description || ''
+									}
 									onChange={ ( value ) =>
 										updateItem(
 											index,

--- a/components/blocks/fau-big-button/edit.js
+++ b/components/blocks/fau-big-button/edit.js
@@ -340,7 +340,7 @@ export default function Edit( { attributes, setAttributes } ) {
 									<p
 										className={ `fau-big-button-character-count ${
 											item.description.length >=
-											DESCRIPTION_MAX_LENGTH * 0.9
+											DESCRIPTION_MAX_LENGTH
 												? 'fau-big-button-character-count--warning'
 												: ''
 										}` }

--- a/components/blocks/fau-big-button/editor.scss
+++ b/components/blocks/fau-big-button/editor.scss
@@ -2,6 +2,21 @@
 
 // Editor-specific styles for FAU Big Button Teaser Group
 
+// Character count styling for sidebar controls
+.fau-big-button-character-count {
+	font-size: 0.75rem;
+	color: #666;
+	margin: 0.25rem 0 0 0;
+	text-align: right;
+	font-style: italic;
+
+	&--warning {
+		color: #d63638;
+		font-weight: 500;
+	}
+}
+
+
 .fau-big-button-teaser-group {
 	// Editor preview styles
 	.block-editor & {

--- a/components/patterns/big-buttons-faculties/editor-wrapper.scss
+++ b/components/patterns/big-buttons-faculties/editor-wrapper.scss
@@ -1,0 +1,38 @@
+.faue-is-big-buttons-faculties-pattern-selected {
+
+	// Hide all block movers by default - target the specific block mover elements
+	.block-editor-block-mover,
+	.block-editor-block-mover__move-button-container,
+	.block-editor-block-mover__drag-handle {
+		display: none;
+	}
+
+	// Hide block lock toolbar to prevent unlocking pattern blocks
+	.block-editor-block-lock-toolbar {
+		display: none;
+	}
+
+	&.faue-is-group-block-selected,
+	&.faue-is-heading-block-selected,
+	&.faue-is-paragraph-block-selected,
+	&.faue-is-buttons-block-selected {
+
+		.block-editor-block-toolbar {
+			// hide all toolbar groups
+			>.components-toolbar-group {
+				display: none;
+			}
+		}
+
+		.block-editor-block-inspector {
+
+			// hide all inspector cards except the block card
+			>:not(.block-editor-block-card) {
+				display: none;
+			}
+		}
+
+	}
+
+
+}

--- a/components/patterns/big-buttons/editor-wrapper.scss
+++ b/components/patterns/big-buttons/editor-wrapper.scss
@@ -1,0 +1,38 @@
+.faue-is-big-buttons-pattern-selected {
+
+	// Hide all block movers by default - target the specific block mover elements
+	.block-editor-block-mover,
+	.block-editor-block-mover__move-button-container,
+	.block-editor-block-mover__drag-handle {
+		display: none;
+	}
+
+	// Hide block lock toolbar to prevent unlocking pattern blocks
+	.block-editor-block-lock-toolbar {
+		display: none;
+	}
+
+	&.faue-is-group-block-selected,
+	&.faue-is-heading-block-selected,
+	&.faue-is-paragraph-block-selected,
+	&.faue-is-buttons-block-selected {
+
+		.block-editor-block-toolbar {
+			// hide all toolbar groups
+			>.components-toolbar-group {
+				display: none;
+			}
+		}
+
+		.block-editor-block-inspector {
+
+			// hide all inspector cards except the block card
+			>:not(.block-editor-block-card) {
+				display: none;
+			}
+		}
+
+	}
+
+
+}

--- a/components/patterns/big-buttons/pattern.php
+++ b/components/patterns/big-buttons/pattern.php
@@ -10,7 +10,7 @@
 
 ?>
 
-<!-- wp:group {"className":"big-buttons"} -->
+<!-- wp:group  {"templateLock":"all", "className":"big-buttons"} -->
 <div class="wp-block-group big-buttons">
     <!-- wp:fau-elemental/fau-meta-headline {"headline":"Fakultäten","id":""} -->
     <div class="wp-block-fau-elemental-fau-meta-headline" id="headline-">Fakultäten</div>

--- a/components/ui/editor/editor-wrapper.scss
+++ b/components/ui/editor/editor-wrapper.scss
@@ -18,6 +18,7 @@
 // Patterns
 @use "../../patterns/hero-portal/editor-wrapper" as *;
 @use "../../patterns/hero-fau/editor-wrapper" as *;
+@use "../../patterns/big-buttons/editor-wrapper" as *;
 
 /**
  * Post Header Component - Editor Wrapper Styles - Hide Editor Features

--- a/components/ui/editor/editor.js
+++ b/components/ui/editor/editor.js
@@ -140,10 +140,26 @@ function getPatternClassFromBlock( block ) {
 		'hero-other',
 	];
 
-	const foundPattern = heroPatterns.find( ( pattern ) =>
+	// Check for big-buttons pattern classes
+	const bigButtonsPatterns = [ 'big-buttons', 'big-buttons-faculties' ];
+
+	// Check hero patterns first
+	const foundHeroPattern = heroPatterns.find( ( pattern ) =>
 		className.includes( pattern )
 	);
-	return foundPattern || null;
+	if ( foundHeroPattern ) {
+		return foundHeroPattern;
+	}
+
+	// Check big-buttons patterns
+	const foundBigButtonsPattern = bigButtonsPatterns.find( ( pattern ) =>
+		className.includes( pattern )
+	);
+	if ( foundBigButtonsPattern ) {
+		return foundBigButtonsPattern;
+	}
+
+	return null;
 }
 
 // Remove the text-color format type

--- a/languages/fau-elemental.pot
+++ b/languages/fau-elemental.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GNU General Public License v3.0.
 msgid ""
 msgstr ""
-"Project-Id-Version: FAU-Elemental 0.2.27\n"
+"Project-Id-Version: FAU-Elemental 0.2.28\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/FAU-Elemental\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-07-25T14:17:49+00:00\n"
+"POT-Creation-Date: 2025-07-28T09:45:07+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.11.0\n"
 "X-Domain: fau-elemental\n"
@@ -104,7 +104,7 @@ msgstr ""
 #: components/templates/pages/page-all-posts.php:105
 #: front-page.php:94
 #: index.php:227
-#: components/blocks/fau-big-button/edit.js:303
+#: components/blocks/fau-big-button/edit.js:306
 #: components/blocks/fau-teaser-grid/components/editor/ContentSettings.jsx:17
 msgid "Title"
 msgstr ""
@@ -571,7 +571,7 @@ msgstr ""
 #: inc/customizer.php:155
 #: inc/customizer.php:181
 #: inc/customizer.php:409
-#: components/blocks/fau-big-button/edit.js:314
+#: components/blocks/fau-big-button/edit.js:317
 msgid "Description"
 msgstr ""
 
@@ -1107,155 +1107,161 @@ msgstr ""
 msgid "Use fewer search terms."
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:68
+#: components/blocks/fau-big-button/edit.js:71
 msgid "Default"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:69
+#: components/blocks/fau-big-button/edit.js:72
 msgid "FAU"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:70
+#: components/blocks/fau-big-button/edit.js:73
 msgid "Philosophy"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:71
+#: components/blocks/fau-big-button/edit.js:74
 msgid "Law & Economics"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:72
+#: components/blocks/fau-big-button/edit.js:75
 msgid "Medicine"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:73
+#: components/blocks/fau-big-button/edit.js:76
 msgid "Sciences"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:74
+#: components/blocks/fau-big-button/edit.js:77
 msgid "Technology"
 msgstr ""
 
 #. translators: %s: faculty type
-#: components/blocks/fau-big-button/edit.js:169
+#: components/blocks/fau-big-button/edit.js:172
 msgid "Using faculty color: %s"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:170
+#: components/blocks/fau-big-button/edit.js:173
 msgid "Unknown"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:180
+#: components/blocks/fau-big-button/edit.js:183
 msgid "Appearance Settings"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:184
+#: components/blocks/fau-big-button/edit.js:187
 msgid "Buttons Per Row"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:188
+#: components/blocks/fau-big-button/edit.js:191
 msgid "4 buttons"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:192
+#: components/blocks/fau-big-button/edit.js:195
 msgid "3 buttons"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:202
+#: components/blocks/fau-big-button/edit.js:205
 msgid "Variant"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:206
+#: components/blocks/fau-big-button/edit.js:209
 msgid "Filled"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:210
+#: components/blocks/fau-big-button/edit.js:213
 msgid "Outline"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:221
+#: components/blocks/fau-big-button/edit.js:224
 msgid "Items"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:226
-#: components/blocks/fau-big-button/edit.js:570
+#: components/blocks/fau-big-button/edit.js:229
+#: components/blocks/fau-big-button/edit.js:607
 msgid "Add Item"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:233
-#: components/blocks/fau-big-button/edit.js:239
+#: components/blocks/fau-big-button/edit.js:236
+#: components/blocks/fau-big-button/edit.js:242
 msgid "Untitled Item"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:234
+#: components/blocks/fau-big-button/edit.js:237
 msgid "Item"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:255
-#: components/blocks/fau-big-button/edit.js:266
-#: components/blocks/fau-big-button/edit.js:461
+#: components/blocks/fau-big-button/edit.js:258
+#: components/blocks/fau-big-button/edit.js:269
+#: components/blocks/fau-big-button/edit.js:488
 msgid "Move up"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:273
-#: components/blocks/fau-big-button/edit.js:286
-#: components/blocks/fau-big-button/edit.js:480
+#: components/blocks/fau-big-button/edit.js:276
+#: components/blocks/fau-big-button/edit.js:289
+#: components/blocks/fau-big-button/edit.js:507
 msgid "Move down"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:298
+#: components/blocks/fau-big-button/edit.js:301
 msgid "Remove Item"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:308
+#: components/blocks/fau-big-button/edit.js:311
 msgid "You can also click on the title in the preview to edit it directly."
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:327
-msgid "You can also click on the description in the preview to edit it directly."
+#. translators: %d: maximum character count
+#: components/blocks/fau-big-button/edit.js:332
+msgid "Maximum %d characters recommended. You can also click on the description in the preview to edit it directly."
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:333
+#. translators: %1$d: current character count, %2$d: maximum character count
+#: components/blocks/fau-big-button/edit.js:350
+msgid "%1$d / %2$d characters"
+msgstr ""
+
+#: components/blocks/fau-big-button/edit.js:360
 msgid "URL"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:354
+#: components/blocks/fau-big-button/edit.js:381
 msgid "Required for display:"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:363
+#: components/blocks/fau-big-button/edit.js:390
 msgid "Title is required"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:371
+#: components/blocks/fau-big-button/edit.js:398
 #: components/utils/urlValidation.js:16
 msgid "URL is required"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:384
+#: components/blocks/fau-big-button/edit.js:411
 msgid "This item will not be displayed on the frontend until both title and URL are provided."
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:395
+#: components/blocks/fau-big-button/edit.js:422
 msgid "Color"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:418
+#: components/blocks/fau-big-button/edit.js:445
 msgid "No items added yet. Click \"Add Item\" to get started."
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:498
+#: components/blocks/fau-big-button/edit.js:525
 msgid "Remove item"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:524
+#: components/blocks/fau-big-button/edit.js:551
 msgid "Enter title…"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:544
+#: components/blocks/fau-big-button/edit.js:581
 msgid "Add description…"
 msgstr ""
 
-#: components/blocks/fau-big-button/edit.js:565
+#: components/blocks/fau-big-button/edit.js:602
 msgid "Add new item"
 msgstr ""
 
@@ -2006,7 +2012,7 @@ msgstr ""
 
 #: components/blocks/fau-big-button/block.json
 msgctxt "block description"
-msgid "Display a group of big buttons"
+msgid "Display a group of big buttons with descriptions limited to 80 characters"
 msgstr ""
 
 #: components/blocks/fau-big-teaser/block.json

--- a/languages/fau-elemental.pot
+++ b/languages/fau-elemental.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-07-28T09:45:07+00:00\n"
+"POT-Creation-Date: 2025-07-28T10:37:23+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.11.0\n"
 "X-Domain: fau-elemental\n"
@@ -2012,7 +2012,7 @@ msgstr ""
 
 #: components/blocks/fau-big-button/block.json
 msgctxt "block description"
-msgid "Display a group of big buttons with descriptions limited to 80 characters"
+msgid "Display a group of big buttons"
 msgstr ""
 
 #: components/blocks/fau-big-teaser/block.json


### PR DESCRIPTION
• Änderungen der Reihenfolge der einzelnen Blöcke (Dachzeile, Überschrift, Text usw…) darf nicht möglich sein. Nur die Reihenfolge der Buttons darf verändert werden
• Im Frontend werden nicht mehr als zwei Zeilen Text ohne Überschrift angezeigt und der restl. Text ggfs. ausgepunktet. Im Backend hat man das Gefühl man kann beliebig Text reinschreiben -> auch im Backend eine Begrenzung vorgeben