### PR TITLE
451 - Teaser Grid - Semantik/Barrierefreiheit

### DIFF
--- a/components/blocks/fau-teaser-grid/edit.js
+++ b/components/blocks/fau-teaser-grid/edit.js
@@ -30,23 +30,29 @@ import {
 
 // Add this helper function at the top level
 const wrapTeaserItems = ( items, layout ) => {
-	// Only wrap for l2s and 2sl layouts
-	if ( ! [ 'l2s', '2sl' ].includes( layout ) ) {
-		return items;
+	if ( [ 'l2s', '2sl' ].includes( layout ) ) {
+		const wrappedItems = [];
+		for ( let i = 0; i < items.length; i += 3 ) {
+			const groupItems = items.slice( i, i + 3 );
+			if ( groupItems.length > 0 ) {
+				wrappedItems.push(
+					<li
+						key={ `teaser-group-${ i }` }
+						className="teaser-group-wrapper"
+					>
+						<div className="teaser-group">{ groupItems }</div>
+					</li>
+				);
+			}
+		}
+		return wrappedItems;
 	}
 
-	const wrappedItems = [];
-	for ( let i = 0; i < items.length; i += 3 ) {
-		const groupItems = items.slice( i, i + 3 );
-		if ( groupItems.length > 0 ) {
-			wrappedItems.push(
-				<div key={ `teaser-group-${ i }` } className="teaser-group">
-					{ groupItems }
-				</div>
-			);
-		}
-	}
-	return wrappedItems;
+	return items.map( ( item, index ) => {
+		// Extract ID from React element props (post.id or page.id)
+		const itemId = item?.props?.post?.id || item?.props?.page?.id || index;
+		return <li key={ itemId }>{ item }</li>;
+	} );
 };
 
 // Generate pagination preview similar to render.php logic
@@ -446,7 +452,7 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 			</BlockControls>
 
 			<div className="fau-teaser-grid-preview">
-				<div
+				<ul
 					ref={ gridRef }
 					className={ `fau-teaser-grid ${ displayStyle } ${
 						displayStyle === 'teaser-grid'
@@ -455,7 +461,6 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 							? 'style-mini-list'
 							: ''
 					}` }
-					role="list"
 					aria-label={ __( 'Content grid', 'fau-elemental' ) }
 				>
 					{ ! isLoading ? (
@@ -499,12 +504,14 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 									teaserLayout
 								)
 							) : (
-								<p role="status">
-									{ __(
-										'No posts selected',
-										'fau-elemental'
-									) }
-								</p>
+								<li className="no-posts">
+									<p role="status">
+										{ __(
+											'No posts selected',
+											'fau-elemental'
+										) }
+									</p>
+								</li>
 							)
 						) : items && items.length > 0 ? (
 							wrapTeaserItems(
@@ -526,9 +533,11 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 								teaserLayout
 							)
 						) : (
-							<p role="status">
-								{ __( 'No items found', 'fau-elemental' ) }
-							</p>
+							<li className="no-posts">
+								<p role="status">
+									{ __( 'No items found', 'fau-elemental' ) }
+								</p>
+							</li>
 						)
 					) : (
 						<Placeholder>
@@ -538,42 +547,42 @@ export default function Edit( { attributes, setAttributes, clientId } ) {
 							</p>
 						</Placeholder>
 					) }
+				</ul>
 
-					{ calculatedTotalPages > 1 &&
-						paginationType === 'numbers' &&
-						showPagination && (
-							<div className="pagination-preview">
-								<nav
-									className="fau-pagination"
-									role="navigation"
-									aria-label={ __(
-										'Posts pagination',
-										'fau-elemental'
+				{ calculatedTotalPages > 1 &&
+					paginationType === 'numbers' &&
+					showPagination && (
+						<div className="pagination-preview">
+							<nav
+								className="fau-pagination"
+								role="navigation"
+								aria-label={ __(
+									'Posts pagination',
+									'fau-elemental'
+								) }
+							>
+								<div className="pagination-wrapper">
+									{ generatePaginationPreview(
+										currentPage,
+										calculatedTotalPages,
+										paginationType
 									) }
-								>
-									<div className="pagination-wrapper">
-										{ generatePaginationPreview(
-											currentPage,
-											calculatedTotalPages,
-											paginationType
-										) }
-									</div>
-								</nav>
-							</div>
-						) }
-
-					{ calculatedTotalPages > 1 &&
-						paginationType === 'load-more' &&
-						showPagination && (
-							<div className="load-more-preview">
-								<div className="wp-block-button is-style-secondary">
-									<button className="wp-block-button__link load-more-button">
-										{ __( 'Load More', 'fau-elemental' ) }
-									</button>
 								</div>
+							</nav>
+						</div>
+					) }
+
+				{ calculatedTotalPages > 1 &&
+					paginationType === 'load-more' &&
+					showPagination && (
+						<div className="load-more-preview">
+							<div className="wp-block-button is-style-secondary">
+								<button className="wp-block-button__link load-more-button">
+									{ __( 'Load More', 'fau-elemental' ) }
+								</button>
 							</div>
-						) }
-				</div>
+						</div>
+					) }
 			</div>
 		</div>
 	);

--- a/components/blocks/fau-teaser-grid/render.php
+++ b/components/blocks/fau-teaser-grid/render.php
@@ -110,7 +110,7 @@ function render_block_fau_teaser_grid( $attributes, $content, $block ) {
     $output = sprintf('<section %s>', $wrapper_attributes);
     
     $output .= sprintf(
-        '<div class="%s" aria-label="%s" data-variant="%s">', 
+        '<ul class="%s" aria-label="%s" data-variant="%s">', 
         esc_attr(implode(' ', $grid_classes)),
         esc_attr__('Content items', 'fau-elemental'),
         esc_attr($variant)
@@ -187,10 +187,10 @@ function render_block_fau_teaser_grid( $attributes, $content, $block ) {
         $items_to_show = array_slice($teaser_items, 0, $posts_per_page);
         $output .= fau_elemental_wrap_teaser_items($teaser_items, $teaser_layout);
     } else {
-        $output .= '<p class="no-posts">' . __('No items found.', 'fau-elemental') . '</p>';
+        $output .= '<li class="no-posts"><p>' . __('No items found.', 'fau-elemental') . '</p></li>';
     }
 
-    $output .= '</div>'; // Close fau-teaser-grid
+    $output .= '</ul>'; // Close fau-teaser-grid
 
     // Add pagination if enabled
     if ($show_pagination && $total_posts > $posts_per_page) {

--- a/components/blocks/fau-teaser-grid/style.scss
+++ b/components/blocks/fau-teaser-grid/style.scss
@@ -10,6 +10,12 @@ section.wp-block-fau-elemental-fau-teaser-grid {
 	.fau-teaser-grid {
 		display: grid;
 		gap: var(--Spacing-8x);
+		list-style: none;
+		max-width: var(--wide-max-width);
+
+		> li {
+			list-style: none;
+		}
 
 		// Global styles
 		&.layout-1xl,
@@ -201,6 +207,10 @@ section.wp-block-fau-elemental-fau-teaser-grid {
 			display: flex;
 			flex-direction: column;
 			gap: var(--Spacing-8x);
+
+			.teaser-group-wrapper {
+				display: contents;
+			}
 
 			.teaser-group {
 				display: grid;

--- a/components/blocks/fau-teaser-grid/teaser-item.php
+++ b/components/blocks/fau-teaser-grid/teaser-item.php
@@ -143,23 +143,26 @@ function fau_elemental_render_teaser_item($post, $variant, $grid_classes, $headi
  */
 if ( ! function_exists( 'fau_elemental_wrap_teaser_items' ) ) {
 function fau_elemental_wrap_teaser_items($items, $layout) {
-    // Only wrap for l2s and 2sl layouts
-    if (!in_array($layout, ['l2s', '2sl'])) {
-        return implode('', $items);
-    }
-
-    $output = '';
-    $item_count = count($items);
-    
-    for ($i = 0; $i < $item_count; $i += 3) {
-        $group_items = array_slice($items, $i, 3);
-        if (!empty($group_items)) {
-            $output .= '<div class="teaser-group">';
-            $output .= implode('', $group_items);
-            $output .= '</div>';
+    if (in_array($layout, ['l2s', '2sl'])) {
+        $output = '';
+        $item_count = count($items);
+        
+        for ($i = 0; $i < $item_count; $i += 3) {
+            $group_items = array_slice($items, $i, 3);
+            if (!empty($group_items)) {
+                $output .= '<li class="teaser-group-wrapper"><div class="teaser-group">';
+                $output .= implode('', $group_items);
+                $output .= '</div></li>';
+            }
         }
+        
+        return $output;
     }
     
-    return $output;
+    $wrapped_items = array_map(function($item) {
+        return '<li>' . $item . '</li>';
+    }, $items);
+    
+    return implode('', $wrapped_items);
 }
 } 

--- a/languages/fau-elemental.pot
+++ b/languages/fau-elemental.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GNU General Public License v3.0.
 msgid ""
 msgstr ""
-"Project-Id-Version: FAU-Elemental 0.4.9\n"
+"Project-Id-Version: FAU-Elemental 0.4.10\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/theme/FAU-Elemental\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2025-11-05T16:25:10+00:00\n"
+"POT-Creation-Date: 2025-11-06T07:13:54+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.11.0\n"
 "X-Domain: fau-elemental\n"
@@ -125,7 +125,7 @@ msgid "Security check failed"
 msgstr ""
 
 #: components/blocks/fau-teaser-grid/render.php:73
-#: components/blocks/fau-teaser-grid/edit.js:459
+#: components/blocks/fau-teaser-grid/edit.js:464
 msgid "Content grid"
 msgstr ""
 
@@ -147,12 +147,12 @@ msgstr ""
 
 #: components/blocks/fau-teaser-grid/render.php:248
 #: components/blocks/fau-teaser-grid/render.php:250
-#: components/blocks/fau-teaser-grid/edit.js:571
+#: components/blocks/fau-teaser-grid/edit.js:581
 msgid "Load More"
 msgstr ""
 
 #: components/blocks/fau-teaser-grid/render.php:249
-#: components/blocks/fau-teaser-grid/edit.js:537
+#: components/blocks/fau-teaser-grid/edit.js:546
 msgid "Loading…"
 msgstr ""
 
@@ -422,7 +422,7 @@ msgid "page-navigation"
 msgstr ""
 
 #: components/template-parts/pagination/pagination.php:24
-#: components/blocks/fau-teaser-grid/edit.js:549
+#: components/blocks/fau-teaser-grid/edit.js:559
 msgid "Posts pagination"
 msgstr ""
 
@@ -933,17 +933,17 @@ msgid "Archive pages settings"
 msgstr ""
 
 #: inc/customizer.php:669
-#: components/blocks/fau-teaser-grid/edit.js:374
+#: components/blocks/fau-teaser-grid/edit.js:380
 msgid "Pagination Type"
 msgstr ""
 
 #: inc/customizer.php:673
-#: components/blocks/fau-teaser-grid/edit.js:378
+#: components/blocks/fau-teaser-grid/edit.js:384
 msgid "Page Numbers"
 msgstr ""
 
 #: inc/customizer.php:674
-#: components/blocks/fau-teaser-grid/edit.js:385
+#: components/blocks/fau-teaser-grid/edit.js:391
 msgid "Load More Button"
 msgstr ""
 
@@ -1592,31 +1592,31 @@ msgstr ""
 
 #: components/blocks/fau-big-teaser/edit.js:85
 #: components/blocks/fau-meta-headline/index.js:28
-#: components/blocks/fau-teaser-grid/edit.js:415
+#: components/blocks/fau-teaser-grid/edit.js:421
 msgid "Heading 2"
 msgstr ""
 
 #: components/blocks/fau-big-teaser/edit.js:89
 #: components/blocks/fau-meta-headline/index.js:34
-#: components/blocks/fau-teaser-grid/edit.js:421
+#: components/blocks/fau-teaser-grid/edit.js:427
 msgid "Heading 3"
 msgstr ""
 
 #: components/blocks/fau-big-teaser/edit.js:93
 #: components/blocks/fau-meta-headline/index.js:40
-#: components/blocks/fau-teaser-grid/edit.js:427
+#: components/blocks/fau-teaser-grid/edit.js:433
 msgid "Heading 4"
 msgstr ""
 
 #: components/blocks/fau-big-teaser/edit.js:97
 #: components/blocks/fau-meta-headline/index.js:46
-#: components/blocks/fau-teaser-grid/edit.js:433
+#: components/blocks/fau-teaser-grid/edit.js:439
 msgid "Heading 5"
 msgstr ""
 
 #: components/blocks/fau-big-teaser/edit.js:101
 #: components/blocks/fau-meta-headline/index.js:52
-#: components/blocks/fau-teaser-grid/edit.js:439
+#: components/blocks/fau-teaser-grid/edit.js:445
 msgid "Heading 6"
 msgstr ""
 
@@ -1848,7 +1848,7 @@ msgid "Choose Logo"
 msgstr ""
 
 #: components/blocks/fau-meta-headline/index.js:25
-#: components/blocks/fau-teaser-grid/edit.js:412
+#: components/blocks/fau-teaser-grid/edit.js:418
 msgid "Change heading level"
 msgstr ""
 
@@ -2029,35 +2029,35 @@ msgstr ""
 msgid "Remove post"
 msgstr ""
 
-#: components/blocks/fau-teaser-grid/edit.js:265
+#: components/blocks/fau-teaser-grid/edit.js:271
 msgid "All Categories"
 msgstr ""
 
-#: components/blocks/fau-teaser-grid/edit.js:318
+#: components/blocks/fau-teaser-grid/edit.js:324
 msgid "Teaser Grid Block"
 msgstr ""
 
-#: components/blocks/fau-teaser-grid/edit.js:361
+#: components/blocks/fau-teaser-grid/edit.js:367
 msgid "Pagination Settings"
 msgstr ""
 
-#: components/blocks/fau-teaser-grid/edit.js:365
+#: components/blocks/fau-teaser-grid/edit.js:371
 msgid "Show Pagination"
 msgstr ""
 
-#: components/blocks/fau-teaser-grid/edit.js:399
+#: components/blocks/fau-teaser-grid/edit.js:405
 msgid "Accessibility"
 msgstr ""
 
-#: components/blocks/fau-teaser-grid/edit.js:401
+#: components/blocks/fau-teaser-grid/edit.js:407
 msgid "To ensure good accessibility and SEO, please make sure that there is only one H1 heading on the page. If you already have an H1 heading, use a different heading level for the teasers in this block."
 msgstr ""
 
-#: components/blocks/fau-teaser-grid/edit.js:503
+#: components/blocks/fau-teaser-grid/edit.js:509
 msgid "No posts selected"
 msgstr ""
 
-#: components/blocks/fau-teaser-grid/edit.js:530
+#: components/blocks/fau-teaser-grid/edit.js:538
 msgid "No items found"
 msgstr ""
 


### PR DESCRIPTION
Changed `<div> to <ul>:` The preview grid container is now a `<ul> `instead of a `<div> with role="list".`
For normal layouts: wraps each teaser item in an `<li> `element