### PR TITLE
485 -  Portalseiten können nicht aufgerufen werden 

### DIFF
--- a/components/blocks/fau-teaser-grid/ajax.php
+++ b/components/blocks/fau-teaser-grid/ajax.php
@@ -84,6 +84,11 @@ function fau_load_more_posts_handler() {
         $query_args['day'] = $selected_day;
     }
 
+    // Add query optimization to prevent memory issues
+    $query_args['no_found_rows'] = false; // We need found_posts for pagination
+    $query_args['update_post_meta_cache'] = true;
+    $query_args['update_post_term_cache'] = true;
+
     // Perform query
     $query = new WP_Query($query_args);
     
@@ -100,6 +105,8 @@ function fau_load_more_posts_handler() {
     }
 
     $html = '';
+    $max_pages = 0;
+    $found_posts = 0;
     
     if ($query->have_posts()) {
         $teaser_items = [];
@@ -109,16 +116,21 @@ function fau_load_more_posts_handler() {
         }
         wp_reset_postdata();
         $html = fau_elemental_wrap_teaser_items($teaser_items, $teaser_layout);
+        $max_pages = $query->max_num_pages;
+        $found_posts = $query->found_posts;
     }
+
+    // Clean up query object before sending response
+    unset($query);
 
     $response = [
         'success' => true,
         'data' => [
             'html' => $html,
-            'has_more' => $query->max_num_pages > $page,
+            'has_more' => $max_pages > $page,
             'current_page' => $page,
-            'max_pages' => $query->max_num_pages,
-            'found_posts' => $query->found_posts
+            'max_pages' => $max_pages,
+            'found_posts' => $found_posts
         ]
     ];
 

--- a/components/blocks/fau-teaser-grid/render.php
+++ b/components/blocks/fau-teaser-grid/render.php
@@ -166,6 +166,11 @@ function render_block_fau_teaser_grid( $attributes, $content, $block ) {
             $query_args['day'] = $selected_day;
         }
 
+        // Add query optimization to prevent memory issues
+        $query_args['no_found_rows'] = false; // We need found_posts for pagination
+        $query_args['update_post_meta_cache'] = true;
+        $query_args['update_post_term_cache'] = true;
+
         $query = new WP_Query($query_args);
         $total_posts = $query->found_posts;
 
@@ -179,6 +184,9 @@ function render_block_fau_teaser_grid( $attributes, $content, $block ) {
             }
             wp_reset_postdata();
         }
+
+        // Clean up query object
+        unset($query);
     }
 
     // Output teaser items

--- a/inc/class-walker-content-menu.php
+++ b/inc/class-walker-content-menu.php
@@ -135,25 +135,51 @@ class Walker_Content_Menu extends Walker_Nav_Menu {
 
     public static function render_portalmenu($slug, $settings = array()) {
         $menu_items = wp_get_nav_menu_items($slug);
+        if (empty($menu_items)) {
+            return '';
+        }
+
         $post_ids = [];
         foreach ($menu_items as $item) {
             if ($item->menu_item_parent === 0 && ($item->object === 'page' || $item->object === 'post')) {
                 $post_ids[] = (int) $item->object_id;
             }
         }
-        _prime_post_caches($post_ids, false, true);
 
-        $query = new WP_Query([
-            'post__in' => $post_ids,
-            'post_type' => ['page', 'post'],
-            'post_status' => 'publish',
-            'nopaging' => true,
-        ]);
-        update_post_thumbnail_cache($query);
+        // Limit to prevent memory issues on large sites - reduced default to 50
+        $max_items = apply_filters('fau_portal_menu_max_items', 50);
+        if (count($post_ids) > $max_items) {
+            $post_ids = array_slice($post_ids, 0, $max_items);
+        }
 
-        $linked_posts = [];
-        foreach ($query->posts as $post) {
-            $linked_posts[$post->ID] = $post;
+        if (!empty($post_ids)) {
+            // Process posts in smaller batches to prevent memory exhaustion
+            // Removed _prime_post_caches() to prevent double-loading and memory issues
+            $linked_posts = [];
+            $batch_size = 20; // Process in smaller batches
+            $batches = array_chunk($post_ids, $batch_size);
+            
+            foreach ($batches as $batch) {
+                $batch_query = new WP_Query([
+                    'post__in' => $batch,
+                    'post_type' => ['page', 'post'],
+                    'post_status' => 'publish',
+                    'posts_per_page' => count($batch),
+                    'no_found_rows' => true,
+                    'update_post_meta_cache' => false, // Skip meta cache to save memory
+                    'update_post_term_cache' => false, // Skip term cache to save memory
+                    'update_post_author_cache' => false, // Skip author cache to save memory
+                ]);
+                
+                foreach ($batch_query->posts as $post) {
+                    $linked_posts[$post->ID] = $post;
+                }
+                
+                wp_reset_postdata();
+                unset($batch_query);
+            }
+        } else {
+            $linked_posts = [];
         }
 
         $menu_filter = function ($items) use ($linked_posts) {


### PR DESCRIPTION
Removed _prime_post_caches() calls
Previously loaded all posts into cache before querying
Caused double-loading of post data
Removed to prevent memory bloat
Simplified query strategy
Removed two-step query (IDs first, then full objects)
Now uses single batch query per batch
Processes in batches of 20 items
Query optimizations
no_found_rows => true - Skip counting total posts
update_post_meta_cache => false - Skip meta cache
update_post_term_cache => false - Skip term cache
update_post_author_cache => false - Skip author cache
Bounded posts_per_page - Limited to 50 items max (configurable)
Memory management
wp_reset_postdata() after each query
unset($batch_query) to free memory immediately
Early return for empty menu items
Reduced default limit
Changed  to 50 items maximum