### PR TITLE
451 - teaser grid locale problem.

### DIFF
--- a/components/blocks/fau-teaser-grid/components/PostTeaser.jsx
+++ b/components/blocks/fau-teaser-grid/components/PostTeaser.jsx
@@ -43,7 +43,7 @@ export default function PostTeaser( { post, headingLevel = 'h4' } ) {
 		// Format date using WordPress locale
 		const locale =
 			( window.fauElemental && window.fauElemental.locale ) || 'en_US';
-		const localeBCP47 = locale.replace( '_', '-' );
+		const localeBCP47 = locale.replace( /_/g, '-' );
 
 		return {
 			day: dateObj


### PR DESCRIPTION
Changed locale.replace('_', '-') to locale.replace(/_/g, '-') on line 46 of PostTeaser.jsx