### PR TITLE
fix(#83) - Add Support for scientific images

### DIFF
--- a/components/core-blocks/image/index.js
+++ b/components/core-blocks/image/index.js
@@ -13,7 +13,7 @@ import { addTallImageClass } from './utils';
 /**
  * Customizes the core/image block by:
  * 1. Removing default and rounded styles
- * 2. Adding custom 'large' and 'medium' styles
+ * 2. Adding custom 'large', 'medium', and 'scientific' styles
  * 3. Creating a default variation with full alignment and overlay
  *
  * This code runs when the DOM is ready and modifies the core image block
@@ -31,6 +31,12 @@ wp.domReady( () => {
 	registerBlockStyle( 'core/image', {
 		name: 'medium',
 		label: __( 'Medium', 'fau-elemental' ),
+		isDefault: false,
+	} );
+
+	registerBlockStyle( 'core/image', {
+		name: 'scientific',
+		label: __( 'Scientific', 'fau-elemental' ),
 		isDefault: false,
 	} );
 

--- a/components/core-blocks/image/style.scss
+++ b/components/core-blocks/image/style.scss
@@ -71,6 +71,53 @@
 		}
 	}
 
+	&.is-style-scientific {
+		max-width: var(--small-max-width);
+
+		&::before {
+			display: none;
+		}
+
+		button.image-fullscreen-btn{
+			display: none;
+		}
+
+		.image-wrapper,
+		&.has-overlay .image-wrapper {
+			box-sizing: border-box;
+			padding: var(--Spacing-4x);
+			padding-inline: 0;
+			padding-bottom: 0;
+
+			&::before {
+				content: none;
+			}
+		}
+
+		img,
+		img.tall-image {
+			aspect-ratio: auto;
+			width: auto;
+			max-width: 100%;
+			height: auto;
+			object-fit: contain;
+		}
+
+		figcaption {
+			box-sizing: border-box;
+			position: static;
+			width: 100%;
+			max-width: none;
+			margin: 0;
+			padding: var(--Spacing-4x) var(--Spacing-6x);
+			padding-inline: 0;
+			transform: none;
+			color: var(--FAU-Col-FAU-Schwarz-90);
+			font-size: var(--P-Caption);
+			text-align: left;
+		}
+	}
+
 	.image-fullscreen-btn {
 		position: absolute;
 		top: 0;

--- a/components/core-blocks/image/style.scss
+++ b/components/core-blocks/image/style.scss
@@ -78,7 +78,7 @@
 			display: none;
 		}
 
-		button.image-fullscreen-btn{
+		button.image-fullscreen-btn {
 			display: none;
 		}
 

--- a/languages/de_DE.po
+++ b/languages/de_DE.po
@@ -1823,19 +1823,23 @@ msgstr "Groß"
 msgid "Medium"
 msgstr "Mittel"
 
+#: components/core-blocks/image/index.js:39
+msgid "Scientific"
+msgstr "Wissenschaftlich"
+
 #: components/core-blocks/cover/index.js:44
-#: components/core-blocks/image/index.js:216
+#: components/core-blocks/image/index.js:222
 #: components/core-blocks/media-text/index.js:73
 msgid "Additional Settings"
 msgstr "Zusätzliche Einstellungen"
 
 #: components/core-blocks/cover/index.js:51
-#: components/core-blocks/image/index.js:222
+#: components/core-blocks/image/index.js:228
 #: components/core-blocks/media-text/index.js:79
 msgid "Copyright Info"
 msgstr "Urheberrechtsinfo"
 
-#: components/core-blocks/image/index.js:233
+#: components/core-blocks/image/index.js:239
 msgid "Add Overlay"
 msgstr "Overlay hinzufügen"
 

--- a/languages/de_DE_formal.po
+++ b/languages/de_DE_formal.po
@@ -1823,19 +1823,23 @@ msgstr "Groß"
 msgid "Medium"
 msgstr "Mittel"
 
+#: components/core-blocks/image/index.js:39
+msgid "Scientific"
+msgstr "Wissenschaftlich"
+
 #: components/core-blocks/cover/index.js:44
-#: components/core-blocks/image/index.js:216
+#: components/core-blocks/image/index.js:222
 #: components/core-blocks/media-text/index.js:73
 msgid "Additional Settings"
 msgstr "Zusätzliche Einstellungen"
 
 #: components/core-blocks/cover/index.js:51
-#: components/core-blocks/image/index.js:222
+#: components/core-blocks/image/index.js:228
 #: components/core-blocks/media-text/index.js:79
 msgid "Copyright Info"
 msgstr "Urheberrechtsinfo"
 
-#: components/core-blocks/image/index.js:233
+#: components/core-blocks/image/index.js:239
 msgid "Add Overlay"
 msgstr "Overlay hinzufügen"
 

--- a/languages/fau-elemental.pot
+++ b/languages/fau-elemental.pot
@@ -2273,13 +2273,13 @@ msgid "Tertiary"
 msgstr ""
 
 #: components/core-blocks/cover/index.js:44
-#: components/core-blocks/image/index.js:216
+#: components/core-blocks/image/index.js:222
 #: components/core-blocks/media-text/index.js:73
 msgid "Additional Settings"
 msgstr ""
 
 #: components/core-blocks/cover/index.js:51
-#: components/core-blocks/image/index.js:222
+#: components/core-blocks/image/index.js:228
 #: components/core-blocks/media-text/index.js:79
 msgid "Copyright Info"
 msgstr ""
@@ -2306,7 +2306,11 @@ msgstr ""
 msgid "Medium"
 msgstr ""
 
-#: components/core-blocks/image/index.js:233
+#: components/core-blocks/image/index.js:39
+msgid "Scientific"
+msgstr ""
+
+#: components/core-blocks/image/index.js:239
 msgid "Add Overlay"
 msgstr ""
 

--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
  * Theme Name:        FAU-Elemental
  * Theme URI:         https://github.com/RRZE-Webteam/FAU-Elemental
  * Description:       General WordPress-Theme of the FAU since 2025
- * Version:           1.0.17
+ * Version:           1.0.18
  * Author:            TBD - theme author
  * Author URI:        TBD - theme author web page
  * Tags:              TBD - theme tags


### PR DESCRIPTION
Adds a new block style for scientific images. As described in #83.
